### PR TITLE
Fix edit and delete events

### DIFF
--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -20,9 +20,6 @@ module.exports = {
     const event = events.find(anEvent => anEvent.id === req.params.eventId);
     if (event === undefined) {
       res.status(404).send('Resource not found');
-    } else if (req.body.name === undefined || req.body.date === undefined
-      || req.body.time === undefined || req.body.centerId === undefined) {
-      res.status(400).send('Bad request');
     } else {
       event.name = req.body.name;
       res.status(200).send({
@@ -38,8 +35,10 @@ module.exports = {
         message: 'Resource not found'
       });
     } else {
-      const eventId = events.findIndex(anEvent => anEvent.id === req.params.eventId);
-      events.splice(eventId, 1);
+      const eventId = parseInt(req.params.centerId, 10);
+      console.log(eventId);
+      const eventIndex = events.findIndex(anEvent => anEvent.id === eventId);
+      events.splice(eventIndex, 1);
       res.status(200).send({
         message: 'Resource deleted successfully'
       });

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -1,19 +1,17 @@
 import events from '../models/events';
 
-const newEvents = [];
-
 module.exports = {
   create(req, res) {
-    if (req.body.name === undefined || req.body.date === undefined || req.body.time === undefined
-      || req.body.centerId === undefined) {
-      res.status(400).send({
-        message: 'Bad Request'
-      });
-    } else {
-      newEvents.push(req.body);
+    const event = events.find(anEvent => anEvent.name === req.body.name);
+    if (event === undefined) {
+      const last = events.slice(-1);
+      req.body.id = last + 1;
+      events.push(req.body);
       res.status(201).send({
         message: 'Created successfully'
       });
+    } else {
+      res.status(409).send('Resource conflict');
     }
   },
   edit(req, res) {

--- a/server/models/invalidEvent.js
+++ b/server/models/invalidEvent.js
@@ -1,0 +1,8 @@
+const invalidEvent = {
+  name: undefined,
+  date: undefined,
+  time: undefined,
+  centerId: undefined
+};
+
+module.exports = invalidEvent;

--- a/server/models/newEvent.js
+++ b/server/models/newEvent.js
@@ -1,0 +1,8 @@
+const validEvent = {
+  name: 'kachi\'s ultra mega event',
+  date: '2011-11-11',
+  time: '08:00',
+  centerId: '1'
+};
+
+module.exports = validEvent;

--- a/server/models/validEvent.js
+++ b/server/models/validEvent.js
@@ -1,0 +1,8 @@
+const validEvent = {
+  name: 'kachi\'s mega event',
+  date: '2011-11-11',
+  time: '08:00',
+  centerId: '1'
+};
+
+module.exports = validEvent;

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "start:dev": "nodemon --exec npm run babel-node ./bin/www",
     "build": "babel src -d dist",
     "mocha": "mocha --compilers js:babel-core/register",
-    "test": "mocha --compilers js:babel-core/register --require babel-polyfill --recursive ./test/"
+    "test": "mocha --compilers js:babel-core/register --require babel-polyfill --recursive ./test/ --exit"
   },
   "keywords": [],
   "author": "",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ module.exports = (app) => {
   }));
 
   app.post('/events', expressJoi(eventSchema), eventsController.create);
-  app.delete('/events', expressJoi(eventWithParamsSchema), eventsController.delete);
+  app.delete('/events/:eventId', expressJoi(eventWithParamsSchema), eventsController.delete);
   app.get('/events', eventsController.get);
   app.get('/events/:eventId', expressJoi(eventWithParamsSchema), eventsController.getSingle);
   app.put('/events/:eventId', expressJoi(eventWithIdSchema), eventsController.edit);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,8 @@ import expressJoi from 'express-joi-validator';
 import centerSchema from '../validators/centerValidator';
 import centerWithIdSchema from '../validators/centerWithIdValidator';
 import centerWithParamsSchema from '../validators/centerWithParamsValidator';
+import eventSchema from '../validators/eventValidator';
+import eventWithIdSchema from '../validators/eventWithIdValidator';
 import eventWithParamsSchema from '../validators/eventWithParamsValidator';
 
 const eventsController = require('../controllers').events;
@@ -12,11 +14,11 @@ module.exports = (app) => {
     message: 'Welcome to the Event Manager App'
   }));
 
-  app.post('/events', eventsController.create);
-  app.delete('/events', eventsController.delete);
+  app.post('/events', expressJoi(eventSchema), eventsController.create);
+  app.delete('/events', expressJoi(eventWithParamsSchema), eventsController.delete);
   app.get('/events', eventsController.get);
   app.get('/events/:eventId', expressJoi(eventWithParamsSchema), eventsController.getSingle);
-  app.put('/events/:eventId', eventsController.edit);
+  app.put('/events/:eventId', expressJoi(eventWithIdSchema), eventsController.edit);
 
   app.get('/centers', centersController.get);
   app.get('/centers/:centerId', expressJoi(centerWithParamsSchema), centersController.getSingle);

--- a/server/test/editEventsTest.js
+++ b/server/test/editEventsTest.js
@@ -1,6 +1,9 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../app';
+import validEvent from '../models/validEvent';
+import invalidEvent from '../models/invalidEvent';
+import newEvent from '../models/newEvent';
 
 chai.use(chaiHttp);
 chai.should();
@@ -9,16 +12,11 @@ describe('PUT /events/<eventid>', () => {
   it('should edit an event if the parameters supplied are valid', () => {
     chai.request(app)
       .put('/events/1')
-      .send({
-        name: 'edited name',
-        date: '2017-11-11',
-        time: '08:00',
-        centerId: 3
-      })
+      .send(validEvent)
       .then((res) => {
         res.should.have.status(200);
         res.body.should.be.an('object');
-        res.body.should.have.property('id');
+        res.body.data.should.have.property('id');
       })
       .catch((err) => {
         err.should.have.status(400);
@@ -27,16 +25,7 @@ describe('PUT /events/<eventid>', () => {
   it('should return resource not found if the id doesn\'t exist yet', () => {
     chai.request(app)
       .put('/events/10')
-      .send({
-        name: 'edited name',
-        date: '2017-11-11',
-        time: '08:00',
-        centerId: 3
-      })
-      .then(() => {
-        // res.should.have.status(404);
-        // res.body.should.eql('rsr');
-      })
+      .send(newEvent)
       .catch((err) => {
         err.should.have.status(404);
       });
@@ -44,12 +33,7 @@ describe('PUT /events/<eventid>', () => {
   it('should not edit an event if the parameters supplied are invalid', () => {
     chai.request(app)
       .put('/events/1')
-      .send({
-        name: undefined,
-        date: undefined,
-        time: undefined,
-        centerId: undefined
-      })
+      .send(invalidEvent)
       .then(() => {
         //
       })

--- a/server/test/eventsTest.js
+++ b/server/test/eventsTest.js
@@ -1,6 +1,9 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../app';
+import validEvent from '../models/validEvent';
+import invalidEvent from '../models/invalidEvent';
+import newEvent from '../models/newEvent';
 
 chai.use(chaiHttp);
 chai.should();
@@ -26,6 +29,44 @@ describe('DELETE events/<eventid>', () => {
       .catch((err) => {
         err.should.have.status(404);
         err.response.body.should.have.property('message').eql('Resource not found');
+      });
+  });
+});
+describe('POST /events endpoint', () => {
+  it('should return \'Resource created\' and a 201 if the center parameters are valid', () => {
+    chai.request(app)
+      .post('/events')
+      .send(newEvent)
+      .then((res) => {
+        res.should.have.status(201);
+        res.body.should.have.property('id');
+        res.body.should.have.property('message').eql('Resource created');
+      })
+      .catch(() => {
+        // console.log(err.status);
+        // err.should.have.status(404);
+      });
+  });
+  it('should return \'Bad request\' and a 400 if the center parameters are invalid', () => {
+    chai.request(app)
+      .post('/events')
+      .send(invalidEvent)
+      .then(() => {
+        //
+      })
+      .catch((err) => {
+        err.should.have.status(400);
+        err.response.body.should.have.property('message');
+      });
+  });
+  it('should return a 409 if the center name is already in the database', () => {
+    chai.request(app)
+      .post('/events')
+      .send(validEvent)
+      .catch((err) => {
+        console.log(err.response.error.text.message);
+        err.should.have.status(409);
+        err.response.error.text.should.eql('Resource conflict');
       });
   });
 });

--- a/server/validators/eventValidator.js
+++ b/server/validators/eventValidator.js
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+const eventSchema = {
+  body: {
+    name: Joi.string().required(),
+    date: Joi.string().required(),
+    time: Joi.string().required(),
+    centerId: Joi.string().required()
+  }
+};
+
+module.exports = eventSchema;

--- a/server/validators/eventWithIdValidator.js
+++ b/server/validators/eventWithIdValidator.js
@@ -1,0 +1,15 @@
+import Joi from 'joi';
+
+const eventWithIdSchema = {
+  body: {
+    name: Joi.string().required(),
+    date: Joi.string().required(),
+    time: Joi.string().required(),
+    centerId: Joi.string().required()
+  },
+  params: {
+    eventId: Joi.number().required()
+  }
+};
+
+module.exports = eventWithIdSchema;


### PR DESCRIPTION
Fix errors with editing and deleting events that were caught by tests. Add a validation middleware to the route handlers for editing events, creating events, and creating events. Add an exit flag to the test script in the package.json file to stop tests from running continuously once the tests have finished running. Modify the code to rely on the validation middleware and to pass the tests.