### PR TITLE
Fix add centers sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "babel-preset-latest": "^6.24.1",
     "babel-register": "^6.26.0",
     "bcrypt": "^1.0.3",
-    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.2",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",

--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -200,7 +200,7 @@ module.exports = {
       .catch(() => {
         res.status(400).send({
           success: false,
-          message: 'An error code'
+          message: 'An error occured'
         });
       });
   }

--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -160,9 +160,9 @@ module.exports = {
           });
         }
       })
-      .catch(error => res.status(400).send({
+      .catch(() => res.status(400).send({
         success: false,
-        error
+        message: 'An error occured'
       }));
   },
   /**
@@ -196,6 +196,12 @@ module.exports = {
             users
           });
         }
+      })
+      .catch(() => {
+        res.status(400).send({
+          success: false,
+          message: 'An error code'
+        });
       });
   }
 };


### PR DESCRIPTION
#### What does this PR do?
Fix issues on the endpoint for adding centers
#### Description of Task to be completed?
* Removed the hard-coded userId and used the ID gotten from the decoded token
* Removed bcryptjs asa dependency
* Handled resource conflict in center names and made it more user friendly
#### How should this be manually tested?
Send a POST request to `https://rocky-meadow-55707.herokuapp.com/api/v2/centers`, with the token passed into the headers, using a key named `x-access-token`, a name, address, capacity, detail of the center, the state that the center is in.
#### Any background context you want to provide?
userId had to be hard-coded because of an issue retrieving tokens on Heroku which has been fixed
#### What are the relevant pivotal tracker stories?(if applicable)
#152943824