### PR TITLE
Fix get single center to return its events

### DIFF
--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -1,4 +1,4 @@
-import db from '../../models/index';
+import { Event, Center, User } from '../../models/index';
 // import { User } from '../../models/index';
 // import { Center } from '../../models/index';
 
@@ -76,7 +76,7 @@ module.exports = {
  */
   /**/
   create(req, res) {
-    db.User
+    User
       .findOne({
         where: { id: req.decoded.id }
       })
@@ -87,7 +87,7 @@ module.exports = {
             message: 'User is not an admin'
           });
         } else if (user.isAdmin) {
-          db.Center
+          Center
             .findOne({
               where: { name: req.body.name }
             })
@@ -98,7 +98,7 @@ module.exports = {
                   message: 'Center already exists'
                 });
               } else if (!center) {
-                db.Center
+                Center
                   .create({
                     name: req.body.name,
                     detail: req.body.detail,
@@ -145,9 +145,12 @@ module.exports = {
   */
   /**/
   getSingleCenter(req, res) {
-    db.Center
+    Center
       .findOne({
-        where: { id: parseInt(req.params.centerId, 10) }
+        where: { id: parseInt(req.params.centerId, 10) },
+        include: [
+          { model: Event, as: 'events' }
+        ]
       })
       .then((center) => {
         if (!center) {
@@ -184,7 +187,7 @@ module.exports = {
   */
   /**/
   getAllCenters(req, res) {
-    db.Center
+    Center
       .findAll({})
       .then((centers) => {
         if (!centers) {
@@ -235,7 +238,7 @@ module.exports = {
  */
   /**/
   edit(req, res) {
-    db.User
+    User
       .findOne({
         where: { id: req.decoded.id }
       })
@@ -246,7 +249,7 @@ module.exports = {
             message: 'User is not an admin'
           });
         } else if (user.isAdmin) {
-          db.Center
+          Center
             .findOne({
               where: { id: parseInt(req.params.centerId, 10) }
             })
@@ -257,7 +260,7 @@ module.exports = {
                   message: 'Center not found'
                 });
               } else if (center) {
-                db.Center
+                Center
                   .findOne({
                     where: { name: req.body.name }
                   })
@@ -268,7 +271,7 @@ module.exports = {
                         message: 'Center name exists'
                       });
                     } else if (!exists) {
-                      db.Center
+                      Center
                         .update({ name: req.body.name }, {
                           where: { id: parseInt(req.params.centerId, 10) }
                         })

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import app from '../../app';
 import newCenterDB from '../../schemas/newCenterDB';
 import './initialize';
+import db from '../../models/index';
 
 chai.should();
 // const { sequelize } = db;
@@ -71,7 +72,8 @@ describe('Centers endpoints', () => {
         .get('/api/v2/centers/1')
         .then((res) => {
           res.should.have.status(200);
-          res.body.should.have.property('events').should.be.an('array');
+          res.body.center.should.have.property('events');
+          res.body.center.events.should.be.an('array');
         })
     ));
     it('should return 404, if the id is invalid or doesn\'t exist', () => (

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -67,14 +67,15 @@ describe('Centers endpoints', () => {
 
   describe('GET /api/v2/centers/<centerId>', () => {
     it('should return 200 and a center, if the id is valid', () => (
-      chai.request(app)
+      request(app)
         .get('/api/v2/centers/1')
         .then((res) => {
           res.should.have.status(200);
+          res.body.should.have.property('events').should.be.an('array');
         })
     ));
     it('should return 404, if the id is invalid or doesn\'t exist', () => (
-      chai.request(app)
+      request(app)
         .get('/api/v2/centers/190888')
         .catch((err) => {
           err.should.have.status(404);

--- a/server/test/v2/initialize.js
+++ b/server/test/v2/initialize.js
@@ -56,14 +56,18 @@ before((done) => {
               ]
             })
             .then((center) => {
-              db.Event
-                .create({
-                  name: 'new event',
-                  date: '2020-01-01',
-                  categoryId: 1,
-                  centerId: center.id
-                })
-                .then(() => {});
+              if (!center) {
+                // do stuff
+              } else {
+                db.Event
+                  .create({
+                    name: 'new event',
+                    date: '2020-01-01',
+                    categoryId: 1,
+                    centerId: center.id
+                  })
+                  .then(() => {});
+              }
             });
         });
       });


### PR DESCRIPTION
#### What does this PR do?
Fix the method for retrieving a single center
#### Description of Task to be completed?
* Modify tests for retrieving a single center so it checks if the events for that center were returned with it
* Modify code for retrieving a single center so it returns its events with it
* Modify initialization file to only create an event if the center exists
#### How should this be manually tested?
Make a request to `https://rocky-meadow-55707.herokuapp.com/api/v2/events/1`
#### Any background context you want to provide?
Initial implementation for retrieving a single center didn't return the center's events
#### What are the relevant pivotal tracker stories?(if applicable)
#152987887