### PR TITLE
Fix add redux to signup component

### DIFF
--- a/client/actions/actionTypes.js
+++ b/client/actions/actionTypes.js
@@ -1,1 +1,2 @@
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const REGISTER_SUCCESS = 'REGISTER_SUCCESS';

--- a/client/actions/registerActions.js
+++ b/client/actions/registerActions.js
@@ -1,0 +1,18 @@
+import * as types from './actionTypes';
+import registerApi from '../api/registerApi';
+
+export function registerSuccess() {
+  return { type: types.registerApi };
+}
+
+export function registerUser(credentials) {
+  return function(dispatch) {
+    return registerApi.register(credentials)
+      .then((response) => {
+        dispatch(registerSuccess());
+      })
+      .catch((error) => {
+        throw (error);
+      });
+  };
+}

--- a/client/actions/registerActions.js
+++ b/client/actions/registerActions.js
@@ -1,5 +1,5 @@
 import * as types from './actionTypes';
-import registerApi from '../api/registerApi';
+import RegisterApi from '../api/registerApi';
 
 export function registerSuccess() {
   return { type: types.registerApi };
@@ -7,7 +7,7 @@ export function registerSuccess() {
 
 export function registerUser(credentials) {
   return function(dispatch) {
-    return registerApi.register(credentials)
+    return RegisterApi.register(credentials)
       .then((response) => {
         dispatch(registerSuccess());
       })

--- a/client/actions/registerActions.js
+++ b/client/actions/registerActions.js
@@ -2,7 +2,7 @@ import * as types from './actionTypes';
 import RegisterApi from '../api/registerApi';
 
 export function registerSuccess() {
-  return { type: types.registerApi };
+  return { type: types.REGISTER_SUCCESS };
 }
 
 export function registerUser(credentials) {

--- a/client/actions/registerActions.js
+++ b/client/actions/registerActions.js
@@ -6,9 +6,10 @@ export function registerSuccess() {
 }
 
 export function registerUser(credentials) {
-  return function(dispatch) {
+  return function (dispatch) {
     return RegisterApi.register(credentials)
       .then((response) => {
+        sessionStorage.setItem('registered', true);
         dispatch(registerSuccess());
       })
       .catch((error) => {

--- a/client/api/registerApi.js
+++ b/client/api/registerApi.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+class RegisterApi {
+  static register(credentials) {
+    return axios.post(
+      'http://localhost:8000/api/v2/users',
+      JSON.stringify({
+        name: `${credentials.firstName} ${credentials.lastName}`,
+        email: credentials.email,
+        password: credentials.password
+      }),
+      { headers: { 'Content-Type': 'application/json' } }
+    )
+      .then(() => {
+        console.log(`Your account was created successfully, ${credentials.firstName}`);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
+}
+export default RegisterApi;

--- a/client/components/Signup.jsx
+++ b/client/components/Signup.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import axios from 'axios';
 import classNames from 'classnames';
 import validator from 'validator';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as registerActions from '../actions/registerActions';
 
 class Signup extends React.Component {
   constructor(props) {
@@ -138,22 +141,11 @@ class Signup extends React.Component {
     event.preventDefault();
     this.resetValidationStates();
     if (this.formIsValid()) {
-      axios.post(
-        'http://localhost:8000/api/v2/users',
-        JSON.stringify({
-          name: `${this.state.firstName.value} ${this.state.lastName.value}`,
-          email: this.state.email.value,
-          password: this.state.password.value
-        }),
-        { headers: { 'Content-Type': 'application/json' } }
-      )
-        .then(() => {
-          alert(`Your account was created successfully, ${this.state.firstName.value}`);
-          this.clearFields();
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+      const credentials = {
+        email: this.state.email.value,
+        password: this.state.password.value
+      };
+      this.props.actions.registerUser(credentials);
     }
   }
   render() {
@@ -261,4 +253,9 @@ class Signup extends React.Component {
     )
   }
 }
-export default Signup;
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(registerActions, dispatch)
+  };
+}
+export default connect(null, mapDispatchToProps)(Signup);

--- a/client/components/Signup.jsx
+++ b/client/components/Signup.jsx
@@ -142,10 +142,12 @@ class Signup extends React.Component {
     this.resetValidationStates();
     if (this.formIsValid()) {
       const credentials = {
+        name: `${this.state.firstName.value} ${this.state.lastName.value}`,
         email: this.state.email.value,
         password: this.state.password.value
       };
       this.props.actions.registerUser(credentials);
+      this.clearFields();
     }
   }
   render() {

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,4 +1,4 @@
 export default {
   session: !!sessionStorage.jwt,
-  isRegistered: false
+  isRegistered: !!sessionStorage.registered
 };

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,3 +1,4 @@
 export default {
-  session: !!sessionStorage.jwt
+  session: !!sessionStorage.jwt,
+  isRegistered: false
 };

--- a/client/reducers/registerReducer.js
+++ b/client/reducers/registerReducer.js
@@ -4,7 +4,7 @@ import initialState from './initialState';
 
 export default function registerReducer(state = initialState.isRegistered, action) {
   switch (action.type) {
-    case 'REGISTER_SUCCESS':
+    case types.REGISTER_SUCCESS:
       history.push('/');
       return !!sessionStorage.registered;
     default:

--- a/client/reducers/registerReducer.js
+++ b/client/reducers/registerReducer.js
@@ -6,7 +6,7 @@ export default function registerReducer(state = initialState.isRegistered, actio
   switch (action.type) {
     case 'REGISTER_SUCCESS':
       history.push('/');
-      return true;
+      return !!sessionStorage.registered;
     default:
       return state;
   }

--- a/client/reducers/registerReducer.js
+++ b/client/reducers/registerReducer.js
@@ -1,0 +1,13 @@
+import history from '../history';
+import * as types from '../actions/actionTypes';
+import initialState from './initialState';
+
+export default function registerReducer(state = initialState.isRegistered, action) {
+  switch (action.type) {
+    case 'REGISTER_SUCCESS':
+      history.push('/');
+      return true;
+    default:
+      return state;
+  }
+}

--- a/client/reducers/rootReducer.js
+++ b/client/reducers/rootReducer.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 import session from './sessionReducer';
+import register from './registerReducer';
 
 const rootReducer = combineReducers({
-  session
+  session,
+  register
 });
 export default rootReducer;


### PR DESCRIPTION
#### What does this PR do?
Use actions and reducers with the signup component
#### Description of Task to be completed?
* Abstract call to the signup endpoint away from the component
* Call an action that handles signing up
* Put the axios call in a class in the API folder
*  Set a registered key in session storage to true from every successful signup and have it reflected in the application's state
#### How should this be manually tested?
Check your browser's session storage after signing up, and you should see a `registered` key set to true
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#153975339