### PR TITLE
Fix return center object in add center endpoint

### DIFF
--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -114,7 +114,17 @@ module.exports = {
                     res.status(201).send({
                       success: true,
                       message: 'Center created successfully',
-                      center: response
+                      center: {
+                        id: response.id,
+                        name: response.name,
+                        address: response.address,
+                        state: response.state,
+                        capacity: response.capacity,
+                        detail: response.detail,
+                        chairs: response.chairs,
+                        projector: response.projector,
+                        image: response.image
+                      }
                     });
                   })
                   .catch(() => res.status(400).send({

--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -105,12 +105,16 @@ module.exports = {
                     capacity: req.body.capacity,
                     address: req.body.address,
                     state: req.body.state,
-                    userId: req.decoded.id
+                    userId: req.decoded.id,
+                    image: req.body.image,
+                    chairs: req.body.chairs,
+                    projector: req.body.projector
                   })
-                  .then(() => {
+                  .then((response) => {
                     res.status(201).send({
                       success: true,
-                      message: 'Center created successfully'
+                      message: 'Center created successfully',
+                      center: response
                     });
                   })
                   .catch(() => res.status(400).send({

--- a/server/models/center.js
+++ b/server/models/center.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     image: {
       type: DataTypes.STRING,
-      defaultValue: '/template/img/ramsey.jpg'
+      defaultValue: './template/img/ramsey.jpg'
     },
     chairs: {
       type: DataTypes.INTEGER,

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -21,13 +21,16 @@ describe('Centers endpoints', () => {
       })
   ));
   describe('POST /api/v2/centers endpoint', () => {
-    it('should return \'Resource created\' and a 201 if the center parameters are valid', () => (
+    it('should return \'Resource created\', a center object and a 201 if the center parameters are valid', () => (
       request(app)
         .post('/api/v2/centers')
         .set('x-access-token', token)
         .send(newCenterDB)
         .then((res) => {
           res.should.have.status(201);
+          res.body.should.have.property('center');
+          res.body.should.have.property('center').should.be.an('object');
+          // res.property('center').should.be.an('object');
           // res.body.should.have.property('id');
           // res.body.should.have.property('message').eql('Center created');
         })


### PR DESCRIPTION
#### What does this PR do?
Return an object with details of a new center
#### Description of Task to be completed?
* Add an object containing a new center to the response object for new centers
* Add keys for chairs, capacity, detail, and projector to the create method for centers
* Add test that checks for the center object inside the response object
* Change the path for the default image in the Center model
#### How should this be manually tested?
For every successful center created, the response should have a center object in it
#### Any background context you want to provide?
Initial response for any center created didn't have the center object in it which is needed in the React component that handles adding new centers
#### What are the relevant pivotal tracker stories?(if applicable)
#152987858