### PR TITLE
Fix add more fields to update method for centers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "classnames": "^2.2.5",
     "cors": "^2.8.4",
     "css-loader": "^0.28.9",
+    "deep-equal": "^1.0.1",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "express-joi-validator": "^2.0.0",

--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -180,10 +180,10 @@ module.exports = {
           });
         }
       })
-      .catch(() => res.status(400).send({
-        success: false,
-        message: 'An error occured'
-      }));
+      // .catch(() => res.status(400).send({
+      //   success: false,
+      //   message: 'An error occured'
+      // }));
   },
   /**
   * @swagger
@@ -275,11 +275,12 @@ module.exports = {
                   message: 'Center not found'
                 });
               } else if (center) {
-                console.log(center.dataValues);
+                // console.log(center.dataValues);
                 let fetchedCenter = center.dataValues;
                 delete fetchedCenter.createdAt;
                 delete fetchedCenter.updatedAt;
                 delete fetchedCenter.id;
+                delete fetchedCenter.userId;
                 if (deepEqual(fetchedCenter, req.body)) {
                   Center
                     .update({
@@ -307,6 +308,52 @@ module.exports = {
                       res.status(400).send({
                         success: false,
                         message: 'An error occured in the centers update'
+                      });
+                    });
+                } else {
+                  Center
+                    .findOne({
+                      where: { name: req.body.name }
+                    })
+                    .then((exists) => {
+                      if (exists) {
+                        res.status(409).send({
+                          success: false,
+                          message: 'Center name exists'
+                        });
+                      } else if (!exists) {
+                        Center
+                          .update({
+                            name: req.body.name,
+                            detail: req.body.detail,
+                            address: req.body.address,
+                            state: req.body.state,
+                            chairs: req.body.chairs,
+                            projector: req.body.projector,
+                            image: req.body.image,
+                            userId: req.decoded.id,
+                            capacity: req.body.capacity
+                          }, {
+                            where: { id: parseInt(req.params.centerId, 10) }
+                          })
+                          .then(() => {
+                            res.status(200).send({
+                              success: true,
+                              message: 'Center updated successfully'
+                            });
+                          })
+                          .catch(() => {
+                            res.status(400).send({
+                              success: false,
+                              message: 'An error occured in the centers update'
+                            });
+                          });
+                      }
+                    })
+                    .catch(() => {
+                      res.status(400).send({
+                        success: false,
+                        message: 'An error occured finding if a center exists'
                       });
                     });
                 }

--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -1,3 +1,4 @@
+import deepEqual from 'deep-equal';
 import { Event, Center, User } from '../../models/index';
 // import { User } from '../../models/index';
 // import { Center } from '../../models/index';
@@ -274,41 +275,41 @@ module.exports = {
                   message: 'Center not found'
                 });
               } else if (center) {
-                Center
-                  .findOne({
-                    where: { name: req.body.name }
-                  })
-                  .then((exists) => {
-                    if (exists) {
-                      res.status(409).send({
-                        success: false,
-                        message: 'Center name exists'
+                console.log(center.dataValues);
+                let fetchedCenter = center.dataValues;
+                delete fetchedCenter.createdAt;
+                delete fetchedCenter.updatedAt;
+                delete fetchedCenter.id;
+                if (deepEqual(fetchedCenter, req.body)) {
+                  Center
+                    .update({
+                      name: req.body.name,
+                      detail: req.body.detail,
+                      address: req.body.address,
+                      state: req.body.state,
+                      chairs: req.body.chairs,
+                      projector: req.body.projector,
+                      image: req.body.image,
+                      userId: req.decoded.id,
+                      capacity: req.body.capacity
+                    }, {
+                      returning: true,
+                      where: { id: parseInt(req.params.centerId, 10) }
+                    })
+                    .then(([rowsUpdate, [updatedCenter]]) => {
+                      res.status(200).send({
+                        success: true,
+                        message: 'Center updated successfully',
+                        center: updatedCenter
                       });
-                    } else if (!exists) {
-                      Center
-                        .update({ name: req.body.name }, {
-                          where: { id: parseInt(req.params.centerId, 10) }
-                        })
-                        .then(() => {
-                          res.status(200).send({
-                            success: true,
-                            message: 'Center updated successfully'
-                          });
-                        })
-                        .catch(() => {
-                          res.status(400).send({
-                            success: false,
-                            message: 'An error occured in the centers update'
-                          });
-                        });
-                    }
-                  })
-                  .catch(() => {
-                    res.status(400).send({
-                      success: false,
-                      message: 'An error occured finding if a center exists'
+                    })
+                    .catch(() => {
+                      res.status(400).send({
+                        success: false,
+                        message: 'An error occured in the centers update'
+                      });
                     });
-                  });
+                }
               }
             })
             .catch(() => {

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -106,6 +106,23 @@ describe('Centers endpoints', () => {
           res.body.should.have.property('message').eql('Center updated successfully');
         })
     ));
+    it('should return a 200 if the request body deep equals a row with the params ID in the database', () => (
+      chai.request(app)
+        .put('/api/v2/centers/1')
+        .set('x-access-token', token)
+        .send({
+          name: 'The main centerssssssss',
+          detail: 'We exis',
+          image: 'ramsey.jpg',
+          address: 'somewhere in lagos',
+          state: 'lagos',
+          capacity: 1000
+        })
+        .catch((err) => {
+          err.should.have.status(200);
+          err.response.body.should.have.property('message').eql('Center updated successfully');
+        })
+    ));
     it('should return a 400 if the parameters were invalid', () => (
       chai.request(app)
         .put('/api/v2/centers/1')
@@ -121,7 +138,7 @@ describe('Centers endpoints', () => {
         .set('x-access-token', token)
         .send({
           name: 'The main centerssssssss',
-          detail: 'We exist',
+          detail: 'We existed',
           image: 'ramsey.jpg',
           address: 'somewhere in lagos',
           state: 'lagos',

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -78,6 +78,9 @@ describe('Centers endpoints', () => {
           res.body.center.should.have.property('events');
           res.body.center.events.should.be.an('array');
         })
+        .catch((err) => {
+          console.log(err);
+        })
     ));
     it('should return 404, if the id is invalid or doesn\'t exist', () => (
       request(app)
@@ -91,7 +94,7 @@ describe('Centers endpoints', () => {
   describe('PUT /api/v1/centers/<centerId>', () => {
     it('should return a 200 if the parameters were valid', () => (
       request(app)
-        .put('/api/v2/centers/1')
+        .put('/api/v2/centers/2')
         .set('x-access-token', token)
         .send({
           name: 'The main centerssssssss',
@@ -111,16 +114,18 @@ describe('Centers endpoints', () => {
         .put('/api/v2/centers/1')
         .set('x-access-token', token)
         .send({
-          name: 'The main centerssssssss',
-          detail: 'We exis',
+          name: 'Center4',
+          detail: 'We exist',
           image: 'ramsey.jpg',
           address: 'somewhere in lagos',
-          state: 'lagos',
-          capacity: 1000
+          chairs: 10,
+          projector: 1,
+          capacity: 1000,
+          state: 'state'
         })
-        .catch((err) => {
-          err.should.have.status(200);
-          err.response.body.should.have.property('message').eql('Center updated successfully');
+        .then((res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('message').eql('Center updated successfully');
         })
     ));
     it('should return a 400 if the parameters were invalid', () => (


### PR DESCRIPTION
#### What does this PR do?
Add more fields to the edit method for centers
#### Description of Task to be completed?
* Handle a scenario where the user doesn't change a center's details before trying to update it
* Write tests for that scenario
* Add more fields to the update calls for a center
* Remove the catch block for the FindOne call inside the getSingleCenter method
#### How should this be manually tested?
Users should be able to update any of a center's fields
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#152987873