### PR TITLE
Fix add more fields to update events endpoint

### DIFF
--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -1,3 +1,4 @@
+import deepEqual from 'deep-equal';
 import { Event, Center, User } from '../../models/index';
 
 module.exports = {
@@ -186,96 +187,59 @@ module.exports = {
         } else if (user.isAdmin) {
           Event
             .findOne({
-              where: { name: req.body.name }
+              where: { id: req.params.eventId },
+              include: [
+                { model: Center }
+              ]
             })
-            .then((exists) => {
-              if (exists) {
-                res.status(409).send({
+            .then((eventObject) => {
+              if (!eventObject) {
+                res.status(404).send({
                   success: false,
-                  message: 'Event name already exists'
+                  message: 'Event not found'
                 });
-              } else {
-                Event
-                  .findOne({
-                    where: { id: req.params.eventId },
-                    include: [
-                      { model: Center }
-                    ]
-                  })
-                  .then((event) => {
-                    if (!event) {
-                      res.status(404).send({
-                        success: false,
-                        message: 'Event not found'
+              } else if (eventObject) {
+                const fetchedEvent = eventObject.dataValues;
+                delete fetchedEvent.createdAt;
+                delete fetchedEvent.updatedAt;
+                delete fetchedEvent.Center;
+                delete fetchedEvent.id;
+                // figure out how to handle status later
+                delete fetchedEvent.status;
+                delete fetchedEvent.userId;
+                console.log(fetchedEvent);
+
+                if (deepEqual(fetchedEvent, req.body) || fetchedEvent.name === req.body.name) {
+                  Event
+                    .update({
+                      name: req.body.name,
+                      guests: req.body.guests,
+                      centerId: req.body.centerId,
+                      detail: req.body.detail,
+                      date: new Date(req.body.date),
+                      categoryId: req.body.categoryId
+                    }, {
+                      returning: true,
+                      where: { id: parseInt(req.params.eventId, 10) }
+                    })
+                    .then(([rowsUpdate, [updatedEvent]]) => {
+                      res.status(200).send({
+                        success: true,
+                        message: 'Event updated successfully',
+                        event: updatedEvent
                       });
-                    } else if (event) {
-                      const centerId = event.Center.id;
-                      Center
-                        .findOne({
-                          where: { id: centerId },
-                          include: [
-                            { model: Event, as: 'events' }
-                          ]
-                        })
-                        .then((center) => {
-                          if (!center) {
-                            res.status(404).send({
-                              success: false,
-                              message: 'Center not found'
-                            });
-                          } else if (center) {
-                            const dates = center.events.map(anEvent => anEvent.date);
-                            if (dates.map(Number).indexOf(+(new Date(req.body.date))) !== -1) {
-                              res.status(409).send({
-                                success: false,
-                                message: 'Oops. Date has already been taken'
-                              });
-                            } else {
-                              Event
-                                .update({
-                                  name: req.body.name,
-                                  date: new Date(req.body.date),
-                                  categoryId: 1
-                                }, {
-                                  where: { id: parseInt(req.params.eventId, 10) }
-                                })
-                                .then(() => {
-                                  res.status(200).send({
-                                    success: true,
-                                    message: 'Event updated successfully'
-                                  });
-                                })
-                                .catch(() => {
-                                  res.status(400).send({
-                                    success: false,
-                                    message: 'An error occured updating event'
-                                  });
-                                });
-                            }
-                          }
-                        })
-                        .catch(() => {
-                          res.status(400).send({
-                            success: false,
-                            message: 'An error occured finding the center'
-                          });
-                        });
-                    }
-                  })
-                  .catch(() => {
-                    res.status(400).send({
-                      success: false,
-                      message: 'An error occured finding the event'
+                    })
+                    .catch(() => {
+                      res.status(400).send({
+                        success: false,
+                        message: 'An error occured updating event'
+                      });
                     });
-                  });
+                } else {
+                  
+                }
               }
             })
-            .catch(() => {
-              res.status(400).send({
-                success: false,
-                message: 'An error occured finding if the event exists'
-              });
-            });
         }
       })
       .catch(() => {

--- a/server/schemas/editEventDB.js
+++ b/server/schemas/editEventDB.js
@@ -3,7 +3,8 @@ const editEventDB = {
   detail: 'Awesome event',
   guests: 1000,
   date: '2018-11-2',
-  categoryId: 1
+  categoryId: 1,
+  centerId: 1
 };
 
 module.exports = editEventDB;

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -92,11 +92,12 @@ describe('Events endpoints', () => {
         .put('/api/v2/events/1')
         .set('x-access-token', token)
         .send({
-          name: 'kachi\'s ultra third event',
+          name: 'kachi\'s ultra mega second event',
           detail: 'Awesome events',
           guests: 1000,
           date: '2018-11-30',
-          categoryId: 1
+          categoryId: 1,
+          centerId: 1
         })
         .expect(409)
         .catch((err) => {
@@ -111,8 +112,9 @@ describe('Events endpoints', () => {
           name: 'kachi\'s ultra dupy event',
           detail: 'Awesome event',
           guests: 1000,
-          date: '2018-11-2',
-          categoryId: 1
+          date: '2019-11-11',
+          categoryId: 1,
+          centerId: 1
         })
         .expect(409)
         .catch((err) => {
@@ -121,9 +123,9 @@ describe('Events endpoints', () => {
     ));
     it('should return a 200 if the request body deep equals a row with the params ID in the database', () => (
       request(app)
-        .put('/api/v2/events/1')
+        .put('/api/v2/events/2')
         .set('x-access-token', token)
-        .send(editEventDB)
+        .send(newEventDB)
         .expect(200)
         .catch((err) => {
           err.should.have.status(200);

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -91,10 +91,42 @@ describe('Events endpoints', () => {
       request(app)
         .put('/api/v2/events/1')
         .set('x-access-token', token)
-        .send(editEventDB)
+        .send({
+          name: 'kachi\'s ultra third event',
+          detail: 'Awesome events',
+          guests: 1000,
+          date: '2018-11-30',
+          categoryId: 1
+        })
         .expect(409)
         .catch((err) => {
           err.should.have.status(409);
+        })
+    ));
+    it('should return a 409 if an event date already exists', () => (
+      request(app)
+        .put('/api/v2/events/1')
+        .set('x-access-token', token)
+        .send({
+          name: 'kachi\'s ultra dupy event',
+          detail: 'Awesome event',
+          guests: 1000,
+          date: '2018-11-2',
+          categoryId: 1
+        })
+        .expect(409)
+        .catch((err) => {
+          err.should.have.status(409);
+        })
+    ));
+    it('should return a 200 if the request body deep equals a row with the params ID in the database', () => (
+      request(app)
+        .put('/api/v2/events/1')
+        .set('x-access-token', token)
+        .send(editEventDB)
+        .expect(200)
+        .catch((err) => {
+          err.should.have.status(200);
         })
     ));
     it('should return a 403 if the token is missing', () => (

--- a/server/validators/eventDBWithParams.js
+++ b/server/validators/eventDBWithParams.js
@@ -6,7 +6,8 @@ const eventDBWithParamsSchema = {
     detail: Joi.string().required(),
     date: Joi.string().required(),
     guests: Joi.number().required(),
-    categoryId: Joi.number().required()
+    categoryId: Joi.number().required(),
+    centerId: Joi.number().required()
   },
   params: {
     eventId: Joi.number().required()


### PR DESCRIPTION
#### What does this PR do?
Add more fields to the sequelize update calls in the edit methods for events
#### Description of Task to be completed?
* Write tests to check that an event is updated if nothing changes in the request body
* Write tests to handle what happens when updating an event when there are changes to the request body
* Write code that updates an event if nothing changes in the request body
* Write code that updates an event if there changes in the request body
#### How should this be manually tested?
Send a request to `http://baseURL/api/v2/events/:eventId` with an object containing the details to be updated
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#152943447