### PR TITLE
Chore split edit center component into presentational and container

### DIFF
--- a/client/components/AddCenter.jsx
+++ b/client/components/AddCenter.jsx
@@ -183,7 +183,7 @@ class AddCenter extends Component {
             addressClasses={addressClasses}
             stateClasses={stateClasses}
             capacityClasses={capacityClasses}
-            addCenter={this.addCenter}
+            saveOrUpdate={this.addCenter}
             handleChange={this.handleChange}
             name={this.state.name}
             chairs={this.state.chairs}

--- a/client/components/AddCenter.jsx
+++ b/client/components/AddCenter.jsx
@@ -68,7 +68,7 @@ class AddCenter extends Component {
     const { name, value } = event.target;
     const field = state[name];
     switch (name) {
-      case 'image':
+      case 'imageUpload':
         this.getSignedRequest(event.target.files[0]);
         break;
       default:
@@ -192,6 +192,7 @@ class AddCenter extends Component {
             detail={this.state.detail}
             address={this.state.address}
             state={this.state.state}
+            image={this.state.image}
           />
         </div>
       </div>

--- a/client/components/Centers.jsx
+++ b/client/components/Centers.jsx
@@ -14,13 +14,14 @@ class Centers extends Component {
     }
   }
   render() {
+    const { isAdmin = false } = this.props;
     return (
       <div>
         <div className="container">
           <Search />
           <div className="top-ten-padding" />
           <div className="row">
-            <CenterList centers={this.props.centers} />
+            <CenterList centers={this.props.centers} isAdmin={isAdmin} />
           </div>
         </div>
       </div>
@@ -30,12 +31,14 @@ class Centers extends Component {
 
 Centers.propTypes = {
   centers: PropTypes.arrayOf(PropTypes.object).isRequired,
-  centerActions: PropTypes.objectOf(PropTypes.func).isRequired
+  centerActions: PropTypes.objectOf(PropTypes.func).isRequired,
+  isAdmin: PropTypes.bool.isRequired
 };
 
 function mapStateToProps(state) {
   return {
-    centers: state.centers
+    centers: state.centers,
+    isAdmin: state.session.isAdmin
   };
 }
 

--- a/client/components/centers/CentersForm.jsx
+++ b/client/components/centers/CentersForm.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 const CentersForm = ({
   name, address, capacity, chairs, projector, state, detail, handleChange,
-  nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, saveOrUpdate
+  nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, saveOrUpdate,
+  component
 }) => (
   <form className="card-content">
     <div className="row">
@@ -16,7 +17,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-name">Name</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-name">Name</label>
+        ) : (
+          <label htmlFor="center-name" className="active">Name</label>
+        )}
         <span className={nameClasses}>{name.message}</span>
       </div>
     </div>
@@ -30,7 +35,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-address">Address</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-address">Address</label>
+        ) : (
+          <label htmlFor="center-address" className="active">Address</label>
+        )}
         <span className={addressClasses}>{address.message}</span>
       </div>
     </div>
@@ -44,7 +53,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-state">State</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-state">State</label>
+        ) : (
+          <label htmlFor="center-state" className="active">State</label>
+        )}
         <span className={stateClasses}>{state.message}</span>
       </div>
     </div>
@@ -58,7 +71,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-capacity">Capacity</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-capacity">Capacity</label>
+        ) : (
+          <label htmlFor="center-capacity" className="active">Capacity</label>
+        )}
         <span className={capacityClasses}>{capacity.message}</span>
       </div>
       <div className="input-field col s4">
@@ -70,7 +87,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-state">Chairs</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-chairs">Chairs</label>
+        ) : (
+          <label htmlFor="center-chairs" className="active">Chairs</label>
+        )}
       </div>
       <div className="input-field col s4">
         <input
@@ -93,7 +114,11 @@ const CentersForm = ({
           className="materialize-textarea validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-detail">Detail</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-detail">Detail</label>
+        ) : (
+          <label htmlFor="center-detail" className="active">Detail</label>
+        )}
         <span className={detailClasses}>{detail.message}</span>
       </div>
     </div>
@@ -170,6 +195,10 @@ CentersForm.propTypes = {
   stateClasses: PropTypes.string.isRequired,
   addressClasses: PropTypes.string.isRequired,
   saveOrUpdate: PropTypes.func.isRequired,
-  handleChange: PropTypes.func.isRequired
+  handleChange: PropTypes.func.isRequired,
+  component: PropTypes.string
+};
+CentersForm.defaultProps = {
+  component: ''
 };
 export default CentersForm;

--- a/client/components/centers/CentersForm.jsx
+++ b/client/components/centers/CentersForm.jsx
@@ -120,7 +120,7 @@ const CentersForm = ({
         className="btn waves-effect waves-light navbar-purple round-btn"
         type="submit"
         name="action"
-        onClick={addCenter}
+        onClick={saveOrUpdate}
       >
         Add Center
         <i className="material-icons right">send</i>

--- a/client/components/centers/CentersForm.jsx
+++ b/client/components/centers/CentersForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const CentersForm = ({
   name, address, capacity, chairs, projector, state, detail, handleChange,
-  nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, addCenter
+  nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, saveOrUpdate
 }) => (
   <form className="card-content">
     <div className="row">
@@ -169,7 +169,7 @@ CentersForm.propTypes = {
   capacityClasses: PropTypes.string.isRequired,
   stateClasses: PropTypes.string.isRequired,
   addressClasses: PropTypes.string.isRequired,
-  addCenter: PropTypes.func.isRequired,
+  saveOrUpdate: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired
 };
 export default CentersForm;

--- a/client/components/centers/CentersForm.jsx
+++ b/client/components/centers/CentersForm.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const CentersForm = ({
   name, address, capacity, chairs, projector, state, detail, handleChange,
   nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, saveOrUpdate,
-  component
+  component, image
 }) => (
   <form className="card-content">
     <div className="row">
@@ -102,7 +102,11 @@ const CentersForm = ({
           className="validate"
           onChange={handleChange}
         />
-        <label htmlFor="center-projector">Projector</label>
+        { component !== 'Edit' ? (
+          <label htmlFor="center-projector">Projector</label>
+        ) : (
+          <label htmlFor="center-projector" className="active">Projector</label>
+        )}
       </div>
     </div>
     <div className="row">
@@ -128,14 +132,16 @@ const CentersForm = ({
           <span>Image</span>
           <input
             type="file"
-            name="image"
+            name="imageUpload"
             onChange={handleChange}
           />
         </div>
         <div className="file-path-wrapper">
           <input
             className="file-path validate"
+            name="image"
             type="text"
+            value={image.value}
           />
         </div>
       </div>
@@ -185,6 +191,11 @@ CentersForm.propTypes = {
     isValid: PropTypes.bool
   }).isRequired,
   state: PropTypes.shape({
+    value: PropTypes.string,
+    message: PropTypes.string,
+    isValid: PropTypes.bool
+  }).isRequired,
+  image: PropTypes.shape({
     value: PropTypes.string,
     message: PropTypes.string,
     isValid: PropTypes.bool

--- a/client/components/centers/EditCenter.jsx
+++ b/client/components/centers/EditCenter.jsx
@@ -90,7 +90,7 @@ class EditCenter extends Component {
     const { name, value } = event.target;
     const field = state[name];
     switch (name) {
-      case 'image':
+      case 'imageUpload':
         this.getSignedRequest(event.target.files[0]);
         break;
       default:
@@ -200,6 +200,7 @@ class EditCenter extends Component {
             detail={this.state.detail}
             address={this.state.address}
             state={this.state.state}
+            image={this.state.image}
             component="Edit"
           />
         </div>

--- a/client/components/centers/EditCenter.jsx
+++ b/client/components/centers/EditCenter.jsx
@@ -22,7 +22,6 @@ class EditCenter extends Component {
       image: { value: '', isValid: true, message: '' },
     };
     this.handleChange = this.handleChange.bind(this);
-    this.handleImageChange = this.handleImageChange.bind(this);
     this.updateCenter = this.updateCenter.bind(this);
   }
   componentDidMount() {
@@ -90,13 +89,16 @@ class EditCenter extends Component {
     const { state } = this;
     const { name, value } = event.target;
     const field = state[name];
-    field.value = value;
-    this.setState({
-      [field]: [field]
-    });
-  }
-  handleImageChange(e) {
-    this.getSignedRequest(e.target.files[0]);
+    switch (name) {
+      case 'image':
+        this.getSignedRequest(event.target.files[0]);
+        break;
+      default:
+        field.value = value;
+        this.setState({
+          [field]: [field]
+        });
+    }
   }
   formIsValid() {
     let fieldCheck = true;

--- a/client/components/centers/EditCenter.jsx
+++ b/client/components/centers/EditCenter.jsx
@@ -200,6 +200,7 @@ class EditCenter extends Component {
             detail={this.state.detail}
             address={this.state.address}
             state={this.state.state}
+            component="Edit"
           />
         </div>
       </div>

--- a/client/components/centers/EditCenter.jsx
+++ b/client/components/centers/EditCenter.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import validator from 'validator';
 import * as centerActions from '../../actions/centerActions';
 import * as singleCenterActions from '../../actions/singleCenterActions';
+import CentersForm from './CentersForm';
 
 class EditCenter extends Component {
   constructor(props) {
@@ -182,127 +183,22 @@ class EditCenter extends Component {
           <div className="container">
             <h3 className="center-heading">Edit a Center</h3>
           </div>
-          <form className="card-content">
-            <div className="row">
-              <div className="input-field col s12">
-                <input
-                  id="center-name"
-                  name="name"
-                  type="text"
-                  className="validate"
-                  value={this.state.name.value}
-                  onChange={this.handleChange}
-                />
-              <label htmlFor="center-name" className="active">Name</label>
-                <span className={nameClasses}>{this.state.name.message}</span>
-              </div>
-            </div>
-            <div className="row">
-              <div className="input-field col s12">
-                <input
-                  id="center-address"
-                  name="address"
-                  type="text"
-                  className="validate"
-                  value={this.state.address.value}
-                  onChange={this.handleChange}
-                />
-                <label htmlFor="center-address" className="active">Address</label>
-                <span className={addressClasses}>{this.state.address.message}</span>
-              </div>
-            </div>
-            <div className="row">
-              <div className="input-field col s12">
-                <input
-                  id="center-state"
-                  name="state"
-                  type="text"
-                  className="validate"
-                  value={this.state.state.value}
-                  onChange={this.handleChange}
-                />
-                <label htmlFor="center-state" className="active">State</label>
-                <span className={stateClasses}>{this.state.state.message}</span>
-              </div>
-            </div>
-            <div className="row">
-              <div className="input-field col s4">
-                <input
-                  id="center-capacity"
-                  name="capacity"
-                  value={this.state.capacity.value}
-                  type="number"
-                  className="validate"
-                  onChange={this.handleChange}
-                />
-              <label for="center-capacity" className="active">Capacity</label>
-                <span className={capacityClasses}>{this.state.capacity.message}</span>
-              </div>
-              <div className="input-field col s4">
-                <input
-                  id="center-chairs"
-                  name="chairs"
-                  value={this.state.chairs.value}
-                  type="number"
-                  className="validate"
-                  onChange={this.handleChange}
-                />
-                <label for="center-state" className="active">Chairs</label>
-              </div>
-              <div className="input-field col s4">
-                <input
-                  id="center-projector"
-                  name="projector"
-                  value={this.state.projector.value}
-                  type="number"
-                  className="validate"
-                  onChange={this.handleChange}
-                />
-                <label for="center-projector" className="active">Projector</label>
-              </div>
-            </div>
-            <div className="row">
-              <div className="input-field col s12">
-                <textarea
-                  id="center-detail"
-                  name="detail"
-                  value={this.state.detail.value}
-                  className="materialize-textarea validate"
-                  onChange={this.handleChange}
-                ></textarea>
-              <label for="center-detail" className="active">Detail</label>
-                <span className={detailClasses}>{this.state.detail.message}</span>
-              </div>
-            </div>
-            <div className="row">
-              <div className="file-field input-field">
-                <div className="btn navbar-purple round-btn">
-                  <span>Image</span>
-                  <input
-                    type="file"
-                    name="image"
-                    onChange={this.handleImageChange}
-                  />
-                </div>
-                <div className="file-path-wrapper">
-                  <input
-                    className="file-path validate"
-                    type="text"
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="row center-align">
-              <button
-                className="btn waves-effect waves-light navbar-purple round-btn"
-                type="submit"
-                name="action"
-                onClick={this.updateCenter}
-              >Update Center
-                <i className="material-icons right">send</i>
-              </button>
-            </div>
-          </form>
+          <CentersForm
+            nameClasses={nameClasses}
+            detailClasses={detailClasses}
+            addressClasses={addressClasses}
+            stateClasses={stateClasses}
+            capacityClasses={capacityClasses}
+            saveOrUpdate={this.updateCenter}
+            handleChange={this.handleChange}
+            name={this.state.name}
+            chairs={this.state.chairs}
+            projector={this.state.projector}
+            capacity={this.state.capacity}
+            detail={this.state.detail}
+            address={this.state.address}
+            state={this.state.state}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
#### What does this PR do?
Split the EditCenter component into container/presentational components
#### Description of Task to be completed?
* Remove the form from the EditCenter component
* Render the CentersForm component in the EditCenter one
#### How should this be manually tested?
The Edit form should work like before
#### Any background context you want to provide?
All functionality for editing centers used to be in a single component
#### What are the relevant pivotal tracker stories?(if applicable)
#155744502