### PR TITLE
Fix redesign single event page

### DIFF
--- a/client/components/common/Login.jsx
+++ b/client/components/common/Login.jsx
@@ -145,7 +145,6 @@ export class Login extends React.Component {
                       name="action"
                       onClick={this.login}
                     >Login
-                      <i className="material-icons right">send</i>
                     </button>
                   </div>
                 </form>

--- a/client/components/common/Signup.jsx
+++ b/client/components/common/Signup.jsx
@@ -255,7 +255,6 @@ export class Signup extends React.Component {
                       name="action"
                     >
                       Signup
-                      <i className="material-icons right">send</i>
                     </button>
                   </div>
                 </form>

--- a/client/components/events/presentational/EventDetails.jsx
+++ b/client/components/events/presentational/EventDetails.jsx
@@ -5,23 +5,41 @@ import * as eventStyles from '../../../css/events.module.css';
 import * as centerStyles from '../../../css/centers.module.css';
 
 const EventDetails = ({ event, center }) => (
-  <div className="col s12 m8 l8">
-    <div className="row">
-      <div className="col s12 m8 l8">
-        <div className="card">
-          <div className="card-image">
-            <img src={center.image} alt="" className="responsive-img" />
-            <span className="card-title">{event.name}</span>
+  <div className="single-event-container">
+    <div className="row" id={eventStyles['single-event-row']}>
+      <div>
+        <img src={center.image} alt="" className="responsive-img col s12 m12 l8 large-event-image" />
+      </div>
+      <div className="col s12 m12 l4" id={eventStyles['event-details-padding']}>
+        <h1 id={eventStyles['break-word']}>{event.name}</h1>
+        <React.Fragment>
+          <p className={eventStyles.tiny}>
+            <span className={eventStyles['tiny-span']}>Date</span>
+          </p>
+          <p className={eventStyles['show-event-details']}>{moment(event.date).format('LL')}</p>
+        </React.Fragment>
+        <div>
+          <div className="show-event-time">
+            <p className={eventStyles.tiny}>
+              <span className={eventStyles['tiny-span']}>Time</span>
+            </p>
+            <p className={eventStyles['show-event-details']}>{moment(event.date).format('LT')}</p>
           </div>
-          <div className="card-content">
-            <p id={centerStyles['show-center-address']}>{event.detail}</p><br />
-            <span id={centerStyles['show-center-state']}>
-              Venue: {center.address}, {center.state}
-            </span><br />
-            <span className={eventStyles['event-date']}>{moment(event.date).format('LT')}</span><br />
-            <span className={eventStyles['event-date']}>Guests: {event.guests}</span>
+          <div>
+            <p className={eventStyles.tiny}>
+              <span className={eventStyles['tiny-span']}>Guest</span>
+            </p>
+            <p className={eventStyles['show-event-details']}>{event.guests}</p>
           </div>
         </div>
+      </div>
+    </div>
+    <div className={eventStyles['single-event-details']}>
+      <div>
+        <h2 className={eventStyles['event-detail']}>
+          <span id={eventStyles['event-detail-span']}>Event Details</span>
+        </h2>
+        <p id={eventStyles['event-detail-text']}>{event.detail}</p>
       </div>
     </div>
   </div>

--- a/client/css/events.module.css
+++ b/client/css/events.module.css
@@ -97,3 +97,87 @@ a, a:link, a:visited, a:active {
   /*list-style-position: outside;*/
   text-rendering: optimizeLegibility;
 }
+.show-event-name {
+  font-size: 5px;
+  margin-top: 0;
+  stroke: transparent;
+  fill: #2e3e48;
+  font-weight: 600;
+  line-height: 1.1;
+  margin-bottom: 8px;
+  text-rendering: optimizeLegibility;
+}
+#break-word {
+  overflow-wrap: break-word;
+  width: 5em;
+}
+.tiny {
+  font-size: 1rem;
+  line-height: 1.6;
+  stroke: transparent;
+  fill: rgba(46,62,72,.35);
+  color: rgba(46,62,72,.35);
+  display: block;
+  margin: 0;
+  padding: 0;
+  font-weight: 400;
+}
+.tiny-span {
+  display: inline;
+}
+.show-event-details {
+  font-weight: 500!important;
+  font-size: 1.2rem;
+  display: block;
+  color: inherit;
+  margin-top: -5px;
+}
+.show-event-date {
+  display: inline-block;
+}
+.show-event-time {
+  display: inline-block;
+}
+.show-center-image {
+  width: 800px;
+  height: auto;
+  margin-left: -11px;
+}
+.single-event-details {
+  padding: 20px 0px 0px 20px;
+}
+.event-detail {
+  font-size: 1.25rem;
+  font-weight: 500!important;
+  line-height: 1.45;
+  stroke: transparent;
+  fill: #2e3e48;
+  color: #2e3e48;
+  display: block;
+}
+#event-detail-span {
+  display: inline;
+  font-weight: 500!important;
+  font-size: 1.25rem;
+  line-height: 1.45;
+  stroke: transparent;
+  fill: #2e3e48;
+  color: #2e3e48;
+  text-rendering: optimizeLegibility;
+}
+#event-detail-text {
+  transition: height .5s cubic-bezier(.215,.61,.355,1);
+  overflow: hidden;
+  line-height: 1.8;
+  display: block;
+  font-size: 1rem;
+  text-rendering: optimizeLegibility;
+  font-weight: 300;
+}
+#single-event-row {
+  margin-right: -12px;
+  margin-left: -11px;
+}
+#event-details-padding {
+  padding-left: 40px;
+}

--- a/client/css/events.module.css
+++ b/client/css/events.module.css
@@ -112,7 +112,7 @@ a, a:link, a:visited, a:active {
   width: 5em;
 }
 .tiny {
-  font-size: 1rem;
+  font-size: 1.3rem;
   line-height: 1.6;
   stroke: transparent;
   fill: rgba(46,62,72,.35);
@@ -147,7 +147,7 @@ a, a:link, a:visited, a:active {
   padding: 20px 0px 0px 20px;
 }
 .event-detail {
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   font-weight: 500!important;
   line-height: 1.45;
   stroke: transparent;
@@ -170,9 +170,9 @@ a, a:link, a:visited, a:active {
   overflow: hidden;
   line-height: 1.8;
   display: block;
-  font-size: 1rem;
+  font-size: 1.5rem;
   text-rendering: optimizeLegibility;
-  font-weight: 300;
+  font-weight: 200;
 }
 #single-event-row {
   margin-right: -12px;


### PR DESCRIPTION
#### What does this PR do?
Redesign single event page
#### Description of Task to be completed?
* Remove image card
* Put image and info about the events in grids
* Put event details in a div underneath the grids
#### How should this be manually tested?
When user opens a page for a single event, then they should see the new design
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#156420768