### PR TITLE
Fix remove history calls in reducers

### DIFF
--- a/client/actions/centerActions.js
+++ b/client/actions/centerActions.js
@@ -62,7 +62,7 @@ export function updateCenter(center) {
     return CenterApi.update(center)
       .then((response) => {
         dispatch(updateCenterSuccess(response.data));
-        return response.data.message;
+        return response.data;
       })
       .catch((error) => {
         // console.log(error);

--- a/client/actions/eventActions.js
+++ b/client/actions/eventActions.js
@@ -19,7 +19,6 @@ export function fetchEvents() {
         dispatch(fetchEventsSuccess(response.data.events));
       })
       .catch((error) => {
-        console.log(error);
         dispatch(fetchEventsFailure(error.data));
       });
   };
@@ -29,13 +28,13 @@ export function fetchSingleEventSuccess(event) {
 }
 
 export function fetchSingleEvent(eventId) {
-  return function (dispatch) {
-    return EventApi.getOne(eventId)
+  return (dispatch) => {
+    EventApi.getOne(eventId)
       .then((response) => {
         dispatch(fetchSingleEventSuccess(response.data.event));
       })
       .catch((error) => {
-        console.log(error);
+        throw (error);
       });
   };
 }
@@ -80,10 +79,9 @@ export function updateEvent(eventObject) {
     return EventApi.update(eventObject)
       .then((response) => {
         dispatch(updateEventSuccess(response.data));
-        return response.data.message;
+        return response.data;
       })
       .catch((error) => {
-        console.log(error);
         throw error.data.message;
       });
   };
@@ -93,13 +91,13 @@ export function deleteEventSuccess(eventId) {
   return { type: types.DELETE_EVENT_SUCCESS, eventId };
 }
 export function deleteEvent(eventId) {
-  return function (dispatch) {
-    return EventApi.deleteEvent(eventId)
+  return (dispatch) => {
+    EventApi.deleteEvent(eventId)
       .then((response) => {
         dispatch(deleteEventSuccess(response));
       })
       .catch((error) => {
-        console.log(error);
+        throw error;
       });
   };
 }

--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -13,7 +13,7 @@ import LoginButtons from './LoginButtons';
 
 export class Home extends React.Component {
   componentDidMount() {
-    $('.parallax').parallax();
+    // $('.parallax').parallax();
     if (this.props.centers.length === 0) {
       this.props.actions.fetchCenters();
     }

--- a/client/components/centers/containers/AddCenter.jsx
+++ b/client/components/centers/containers/AddCenter.jsx
@@ -8,6 +8,7 @@ import axios from 'axios';
 import * as centerActions from '../../../actions/centerActions';
 import CentersForm from '../presentational/CentersForm';
 import Preloader from '../../common/Preloader';
+import history from '../../../history';
 
 export class AddCenter extends Component {
   constructor(props) {
@@ -162,9 +163,11 @@ export class AddCenter extends Component {
     };
     if (this.formIsValid()) {
       this.props.centerActions.addCenter(center)
-        .then(response => Materialize.toast(response, 4000, 'green'))
+        .then((response) => {
+          Materialize.toast(response, 4000, 'green');
+          history.push('/centers');
+        })
         .catch(error => Materialize.toast(error, 4000, 'red'));
-      // this.clearFields();
     }
   }
   render() {

--- a/client/components/centers/containers/Centers.jsx
+++ b/client/components/centers/containers/Centers.jsx
@@ -15,12 +15,6 @@ export class Centers extends Component {
       this.props.centerActions.fetchCenters();
     }
   }
-  // componentWillReceiveProps(nextProps) {
-  //   console.log(nextProps);
-  //   if (this.props.centers.length !== nextProps.centers.length) {
-  //     this.props.centers = nextProps.centers;
-  //   }
-  // }
   render() {
     const { isAdmin = false } = this.props;
     const { centers = [] } = this.props;
@@ -28,7 +22,7 @@ export class Centers extends Component {
       return (
         <Preloader />
       );
-    } else if (this.props.centers.length === 0) {
+    } else if (centers.length === 0) {
       return (
         <div className="min-height-hundred-vh">
           Sorry no centers found
@@ -62,13 +56,11 @@ Centers.propTypes = {
   centerActions: PropTypes.objectOf(PropTypes.func).isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool,
-  message: PropTypes.string
 };
 
 Centers.defaultProps = {
   centers: [],
   isLoading: false,
-  message: ''
 };
 
 function mapStateToProps(state) {

--- a/client/components/centers/containers/Centers.jsx
+++ b/client/components/centers/containers/Centers.jsx
@@ -15,6 +15,12 @@ export class Centers extends Component {
       this.props.centerActions.fetchCenters();
     }
   }
+  // componentWillReceiveProps(nextProps) {
+  //   console.log(nextProps);
+  //   if (this.props.centers.length !== nextProps.centers.length) {
+  //     this.props.centers = nextProps.centers;
+  //   }
+  // }
   render() {
     const { isAdmin = false } = this.props;
     const { centers = [] } = this.props;
@@ -22,7 +28,7 @@ export class Centers extends Component {
       return (
         <Preloader />
       );
-    } else if (this.props.message !== '') {
+    } else if (this.props.centers.length === 0) {
       return (
         <div className="min-height-hundred-vh">
           Sorry no centers found

--- a/client/components/centers/containers/EditCenter.jsx
+++ b/client/components/centers/containers/EditCenter.jsx
@@ -7,6 +7,7 @@ import validator from 'validator';
 import * as centerActions from '../../../actions/centerActions';
 import * as singleCenterActions from '../../../actions/singleCenterActions';
 import CentersForm from '../presentational/CentersForm';
+import history from '../../../history';
 
 export class EditCenter extends Component {
   constructor(props) {
@@ -171,7 +172,10 @@ export class EditCenter extends Component {
     };
     if (this.formIsValid()) {
       this.props.actions.updateCenter(center)
-        .then(response => Materialize.toast(response, 4000, 'green'))
+        .then((response) => {
+          Materialize.toast(response.message, 4000, 'green');
+          history.push(`/centers/${response.center.id}`);
+        })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
   }

--- a/client/components/common/Login.jsx
+++ b/client/components/common/Login.jsx
@@ -125,7 +125,11 @@ export class Login extends React.Component {
                         className="validate"
                         onChange={this.handleEmailChange}
                       />
-                      <label htmlFor="email">Email</label>
+                      { this.state.email.value === '' ? (
+                        <label htmlFor="email">Email</label>
+                      ) : (
+                        <label htmlFor="email" className="active">Email</label>
+                      )}
                       <span className={emailClasses}>{this.state.email.message}</span>
                     </div>
                   </div>
@@ -138,7 +142,11 @@ export class Login extends React.Component {
                         className="validate"
                         onChange={this.handlePasswordChange}
                       />
-                      <label htmlFor="password">Password</label>
+                      { this.state.password.value === '' ? (
+                        <label htmlFor="password">Password</label>
+                      ) : (
+                        <label htmlFor="password" className="active">Password</label>
+                      )}
                       <span className={passwordClasses}>{this.state.password.message}</span>
                     </div>
                   </div>

--- a/client/components/common/Login.jsx
+++ b/client/components/common/Login.jsx
@@ -7,6 +7,7 @@ import validator from 'validator';
 import PropTypes from 'prop-types';
 import * as sessionActions from '../../actions/sessionActions';
 import Preloader from './Preloader';
+import history from '../../history';
 
 export class Login extends React.Component {
   constructor(props) {
@@ -90,7 +91,10 @@ export class Login extends React.Component {
     };
     if (this.formIsValid()) {
       this.props.actions.loginUser(credentials)
-        .then(response => Materialize.toast(response, 4000, 'green'))
+        .then((response) => {
+          Materialize.toast(response, 4000, 'green');
+          history.push('/');
+        })
         .catch(error => Materialize.toast(error, 4000, 'red'));
       // this.clearFields();
     }

--- a/client/components/common/Signup.jsx
+++ b/client/components/common/Signup.jsx
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as registerActions from '../../actions/registerActions';
 import Preloader from './Preloader';
+import history from '../../history';
 
 export class Signup extends React.Component {
   constructor(props) {
@@ -151,9 +152,13 @@ export class Signup extends React.Component {
         password: this.state.password.value
       };
       this.props.actions.registerUser(credentials)
-        .then(response => Materialize.toast(response, 4000, 'green'))
-        .catch(error => Materialize.toast(error, 4000, 'red'));
-      this.clearFields();
+        .then((response) => {
+          Materialize.toast(response, 4000, 'green');
+          history.push('/');
+        })
+        .catch((error) => {
+          Materialize.toast(error, 4000, 'red');
+        });
     }
   }
   render() {
@@ -191,7 +196,11 @@ export class Signup extends React.Component {
                         className="validate"
                         onChange={this.handleFirstNameChange}
                       />
-                      <label htmlFor="first_name">First Name</label>
+                      { this.state.firstName.value === '' ? (
+                        <label htmlFor="first_name">First Name</label>
+                      ) : (
+                        <label htmlFor="first_name" className="active">First Name</label>
+                      )}
                       <span className={firstNameClasses}>{this.state.firstName.message}</span>
                     </div>
                     <div className="input-field col s6">
@@ -202,7 +211,11 @@ export class Signup extends React.Component {
                         className="validate"
                         onChange={this.handleLastNameChange}
                       />
-                      <label htmlFor="last_name">Last Name</label>
+                      { this.state.lastName.value === '' ? (
+                        <label htmlFor="last_name">Last Name</label>
+                      ) : (
+                        <label htmlFor="last_name" className="active">Last Name</label>
+                      )}
                       <span className={lastNameClasses}>{this.state.lastName.message}</span>
                     </div>
                   </div>
@@ -215,7 +228,11 @@ export class Signup extends React.Component {
                         className="validate"
                         onChange={this.handleEmailChange}
                       />
-                      <label htmlFor="email">Email</label>
+                      { this.state.email.value === '' ? (
+                        <label htmlFor="email">Email</label>
+                      ) : (
+                        <label htmlFor="email" className="active">Email</label>
+                      )}
                       <span className={emailClasses}>{this.state.email.message}</span>
                     </div>
                   </div>
@@ -228,7 +245,11 @@ export class Signup extends React.Component {
                         className="validate"
                         onChange={this.handlePasswordChange}
                       />
-                      <label htmlFor="password">Password</label>
+                      { this.state.password.value === '' ? (
+                        <label htmlFor="password">Password</label>
+                      ) : (
+                        <label htmlFor="password" className="active">Password</label>
+                      )}
                       <span className={passwordClasses}>{this.state.password.message}</span>
                     </div>
                     <div className="input-field col s6">
@@ -239,7 +260,11 @@ export class Signup extends React.Component {
                         className="validate"
                         onChange={this.handlePasswordConfirmationChange}
                       />
-                      <label htmlFor="password_confirmation">Password Confirmation</label>
+                      { this.state.passwordConfirmation.value === '' ? (
+                        <label htmlFor="password_confirmation">Confirm Password</label>
+                      ) : (
+                        <label htmlFor="password_confirmation" className="active">Confirm Password</label>
+                      )}
                       <span
                         className={passwordConfirmationClasses}
                       >

--- a/client/components/events/container/AddEvent.jsx
+++ b/client/components/events/container/AddEvent.jsx
@@ -10,6 +10,7 @@ import MenuItem from 'material-ui/MenuItem';
 import * as eventActions from '../../../actions/eventActions';
 import * as centerActions from '../../../actions/centerActions';
 import EventsForm from '../presentational/EventsForm';
+import history from '../../../history';
 
 export class AddEvent extends Component {
   constructor(props) {
@@ -204,9 +205,11 @@ export class AddEvent extends Component {
     };
     if (this.formIsValid()) {
       this.props.actions.addEvent(eventObject)
-        .then(response => Materialize.toast(response, 4000, 'green'))
+        .then((response) => {
+          Materialize.toast(response, 4000, 'green');
+          history.push('/events');
+        })
         .catch(error => Materialize.toast(error, 4000, 'red'));
-      // this.clearFields();
     }
   }
   render() {

--- a/client/components/events/container/EditEvent.jsx
+++ b/client/components/events/container/EditEvent.jsx
@@ -10,6 +10,7 @@ import MenuItem from 'material-ui/MenuItem';
 import * as eventActions from '../../../actions/eventActions';
 import * as centerActions from '../../../actions/centerActions';
 import EventsForm from '../presentational/EventsForm';
+import history from '../../../history';
 
 class EditEvent extends Component {
   constructor(props) {
@@ -210,7 +211,10 @@ class EditEvent extends Component {
     };
     if (this.formIsValid()) {
       this.props.actions.updateEvent(eventObject)
-        .then(response => Materialize.toast(response, 4000, 'green'))
+        .then((response) => {
+          Materialize.toast(response.message, 4000, 'green');
+          history.push(`/events/${response.event.id}`);
+        })
         .catch(error => Materialize.toast(error, 4000, 'red'));
       // this.clearFields();
     }

--- a/client/components/events/container/Events.jsx
+++ b/client/components/events/container/Events.jsx
@@ -22,16 +22,17 @@ export class Events extends Component {
     this.props.actions.deleteEvent(parseInt(id, 10));
   }
   render() {
+    const { events = [] } = this.props;
     if (this.props.isLoading) {
       return (
         <Preloader />
       );
     }
-    if (this.props.message !== '') {
+    if (events.length === 0) {
       return (
-        <diV className="container min-height-hundred-vh">
+        <div className="container min-height-hundred-vh">
           <p>No events found yet</p>
-        </diV>
+        </div>
       );
     }
     return (
@@ -40,7 +41,7 @@ export class Events extends Component {
         <div className="top-ten-padding" />
         <div className="row">
           <EventsListWithImage
-            events={this.props.events}
+            events={events}
             deleteEvent={this.deleteEvent}
             isAdmin={this.props.isAdmin}
           />

--- a/client/components/events/presentational/EventsListWithImage.jsx
+++ b/client/components/events/presentational/EventsListWithImage.jsx
@@ -11,8 +11,8 @@ const EventsListWithImage = ({
   <div>
     {events.map(event => (
       <div className="col s12 m6 l4 hvr-grow" key={event.id}>
-        <Link to={`/events/${event.id}`}>
-          <div className="card z-depth-2">
+        <div className="card z-depth-2">
+          <Link to={`/events/${event.id}`}>
             <div className="card-image">
               <img src={owenShaw} alt={`${event.name}`} className="event-image" />
             </div>
@@ -21,28 +21,28 @@ const EventsListWithImage = ({
               <span className={styles['event-date']}>{moment(event.date).format('LL')}</span><br />
               <span className={styles['fifteen-percent']}>{moment(event.date).format('LT')}</span>
             </div>
-            { isAdmin || loggedIn ? (
-              <div className="card-action">
-                <React.Fragment>
-                  <Link
-                    to={`/events/${event.id}/edit`}
-                    className="waves-effect waves-light btn navbar-purple round-btn white-color left-align"
-                  >
-                    <i className="material-icons">edit</i>
-                  </Link>
-                  <button
-                    onClick={() => deleteEvent(event.id)}
-                    className="waves-effect waves-light btn navbar-purple round-btn white-color right"
-                  >
-                    <i className="material-icons">delete</i>
-                  </button>
-                </React.Fragment>
-              </div>
-            ) : (
-              <React.Fragment />
-            )}
-          </div>
-        </Link>
+          </Link>
+          { isAdmin || loggedIn ? (
+            <div className="card-action">
+              <React.Fragment>
+                <Link
+                  to={`/events/${event.id}/edit`}
+                  className="waves-effect waves-light btn navbar-purple round-btn white-color left-align"
+                >
+                  <i className="material-icons">edit</i>
+                </Link>
+                <button
+                  onClick={() => deleteEvent(event.id)}
+                  className="waves-effect waves-light btn navbar-purple round-btn white-color right"
+                >
+                  <i className="material-icons">delete</i>
+                </button>
+              </React.Fragment>
+            </div>
+          ) : (
+            <React.Fragment />
+          )}
+        </div>
       </div>
   ))}
   </div>

--- a/client/index.js
+++ b/client/index.js
@@ -5,12 +5,12 @@ import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import rootReducer from './reducers/rootReducer';
 import App from './components/App';
 import history from './history';
-import { fetchCenters } from './actions/centerActions';
-import { fetchEvents } from './actions/eventActions';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+// import { fetchCenters } from './actions/centerActions';
+// import { fetchEvents } from './actions/eventActions';
 
 const createStoreWithMiddleware = composeWithDevTools(
   applyMiddleware(thunkMiddleware))(createStore);

--- a/client/reducers/centerReducer.js
+++ b/client/reducers/centerReducer.js
@@ -1,14 +1,11 @@
 import update from 'immutability-helper';
 import initialState from './initialState';
-import history from '../history';
 import * as types from '../actions/actionTypes';
 
 export default function centerReducer(state = initialState.centers, action) {
   let newState = {};
   switch (action.type) {
     case types.ADD_CENTER_SUCCESS:
-      history.push('/centers');
-      // console.log(action);
       return (Object.assign(
         {},
         state,
@@ -22,8 +19,6 @@ export default function centerReducer(state = initialState.centers, action) {
         { message: action.center.message }
       ));
     case types.ADD_CENTER_FAILURE:
-      // console.log(action);
-      history.push('/add-center');
       return (Object.assign(
         {},
         state,
@@ -59,7 +54,6 @@ export default function centerReducer(state = initialState.centers, action) {
         { isLoading: true },
       ));
     case types.UPDATE_CENTER_SUCCESS:
-      history.push(`/centers/${action.center.center.id}`);
       return (Object.assign(
         {},
         state,

--- a/client/reducers/centerReducer.js
+++ b/client/reducers/centerReducer.js
@@ -2,35 +2,43 @@ import update from 'immutability-helper';
 import initialState from './initialState';
 import * as types from '../actions/actionTypes';
 
+function addCenterReducer(state = [], action) {
+  let newState = {};
+  switch (action.type) {
+    case types.ADD_CENTER_SUCCESS:
+      newState = update(state, {
+        $set: [
+          ...state.filter(center => center.id !== action.center.center.id),
+          Object.assign({}, action.center.center)
+        ]
+      });
+      return newState;
+    default:
+      return state;
+  }
+}
+
 export default function centerReducer(state = initialState.centers, action) {
   let newState = {};
   switch (action.type) {
     case types.ADD_CENTER_SUCCESS:
-      return (Object.assign(
-        {},
-        state,
-        {
-          centers: [
-            ...state.centers.filter(center => center.id !== action.center.center.id),
-            Object.assign({}, action.center.center)
-          ]
-        },
-        { isLoading: false },
-        { message: action.center.message }
-      ));
+      newState = update(state, {
+        centers: { $set: addCenterReducer(state.centers, action) },
+        isLoading: { $set: false },
+        message: { $set: action.center.message }
+      });
+      return newState;
     case types.ADD_CENTER_FAILURE:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: false },
-        { message: action.center.data.message }
-      ));
+      newState = update(state, {
+        isLoading: { $set: false },
+        message: { $set: action.center.data.message }
+      });
+      return newState;
     case types.ADD_CENTER_LOADING:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: true }
-      ));
+      newState = update(state, {
+        isLoading: { $set: true }
+      });
+      return newState;
     case types.FETCH_CENTERS_SUCCESS:
       newState = update(state, {
         centers: {
@@ -42,43 +50,38 @@ export default function centerReducer(state = initialState.centers, action) {
       });
       return newState;
     case types.FETCH_CENTERS_FAILURE:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: false },
-        // { message: action.centers.message }
-      ));
+      newState = update(state, {
+        isLoading: { $set: false }
+      });
+      return newState;
     case types.FETCH_CENTERS_LOADING:
-      return (Object.assign(
-        {},
-        { isLoading: true },
-      ));
+      newState = update(state, {
+        isLoading: { $set: true }
+      });
+      return newState;
     case types.UPDATE_CENTER_SUCCESS:
-      return (Object.assign(
-        {},
-        state,
-        {
-          centers: [
+      newState = update(state, {
+        centers: {
+          $set: [
             ...state.centers.filter(center => center.id !== action.center.center.id),
             Object.assign({}, action.center.center)
           ]
         },
-        { isLoading: false },
-        { message: action.center.message }
-      ));
+        isLoading: { $set: false },
+        message: { $set: action.center.message }
+      });
+      return newState;
     case types.UPDATE_CENTER_FAILURE:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: false },
-        { message: action.center.data.message }
-      ));
+      newState = update(state, {
+        isLoading: { $set: false },
+        message: { $set: action.center.data.message }
+      });
+      return newState;
     case types.UPDATE_CENTER_LOADING:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: true }
-      ));
+      newState = update(state, {
+        isLoading: { $set: true }
+      });
+      return newState;
     default:
       return state;
   }

--- a/client/reducers/eventReducer.js
+++ b/client/reducers/eventReducer.js
@@ -1,13 +1,11 @@
 import update from 'immutability-helper';
 import initialState from './initialState';
-import history from '../history';
 import * as types from '../actions/actionTypes';
 
 function addEventReducer(state = [], action) {
   let newState = {};
   switch (action.type) {
     case types.ADD_EVENT_SUCCESS:
-      console.log(state);
       newState = update(state, {
         $set: [
           ...state.filter(event => event.id !== action.event.event.id),
@@ -52,35 +50,33 @@ export default function eventReducer(state = initialState.events, action) {
       });
       return theState;
     case types.UPDATE_EVENT_SUCCESS:
-      history.push(`/events/${action.event.event.id}`);
-      return (Object.assign(
-        {},
-        state,
-        {
-          events: [
+      theState = update(state, {
+        events: {
+          $set: [
             ...state.events.filter(event => event.id !== action.event.event.id),
             Object.assign({}, action.event.event)
           ]
         },
-        { message: action.event.message },
-        { isLoading: false }
-      ));
+        message: { $set: action.event.message },
+        isLoading: { $set: false }
+      });
+      return theState;
     case types.UPDATE_EVENT_FAILURE:
-      history.push(`/events/${action.event.event.id}/edit`);
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: false },
-        { message: action.event.data.message }
-      ));
+      theState = update(state, {
+        isLoading: { $set: false },
+        message: { $set: action.event.data.message }
+      });
+      return theState;
     case types.DELETE_EVENT_SUCCESS:
-      const newState = Object.assign([], state);
-      const indexOfEvent = state.events.findIndex(event => event.id === action.eventId);
-      newState.splice(indexOfEvent, 1);
-      history.push('/admin');
-      return newState;
+      theState = update(state, {
+        events: {
+          $set: [
+            ...state.events.filter(event => event.id !== action.eventId)
+          ]
+        }
+      });
+      return theState;
     case types.ADD_EVENT_SUCCESS:
-      console.log(action);
       theState = update(state, {
         events: { $set: addEventReducer(state.events, action) },
         isLoading: { $set: false },

--- a/client/reducers/registerReducer.js
+++ b/client/reducers/registerReducer.js
@@ -1,30 +1,28 @@
-import history from '../history';
+import update from 'immutability-helper';
 import * as types from '../actions/actionTypes';
 import initialState from './initialState';
 
 export default function registerReducer(state = initialState.register, action) {
+  let newState = {};
   switch (action.type) {
     case types.REGISTER_LOADING:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: true }
-      ));
+      newState = update(state, {
+        isLoading: { $set: true }
+      });
+      return newState;
     case types.REGISTER_SUCCESS:
-      return (Object.assign(
-        {},
-        state,
-        !!sessionStorage.registered,
-        { message: action.response.data.message },
-        { isLoading: false }
-      ));
+      newState = update(state, {
+        isRegistered: { $set: !!sessionStorage.registered },
+        message: { $set: action.response.data.message },
+        isLoading: { $set: false }
+      });
+      return newState;
     case types.REGISTER_FAILURE:
-      return (Object.assign(
-        {},
-        state,
-        { message: action.response.data.message },
-        { isLoading: false }
-      ));
+      newState = update(state, {
+        message: { $set: action.response.data.message },
+        isLoading: { $set: false }
+      });
+      return newState;
     default:
       return state;
   }

--- a/client/reducers/registerReducer.js
+++ b/client/reducers/registerReducer.js
@@ -11,7 +11,6 @@ export default function registerReducer(state = initialState.register, action) {
         { isLoading: true }
       ));
     case types.REGISTER_SUCCESS:
-      history.push('/');
       return (Object.assign(
         {},
         state,
@@ -20,7 +19,6 @@ export default function registerReducer(state = initialState.register, action) {
         { isLoading: false }
       ));
     case types.REGISTER_FAILURE:
-      history.push('/signup');
       return (Object.assign(
         {},
         state,

--- a/client/reducers/sessionReducer.js
+++ b/client/reducers/sessionReducer.js
@@ -7,7 +7,6 @@ export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export default function sessionReducer(state = initialState.session, action) {
   switch (action.type) {
     case types.LOGIN_SUCCESS:
-      history.push('/');
       return (Object.assign(
         {},
         state,
@@ -32,7 +31,6 @@ export default function sessionReducer(state = initialState.session, action) {
         { isLoading: true }
       ));
     case types.LOGOUT_SUCCESS:
-      history.push('/');
       return (Object.assign(
         {},
         state,

--- a/client/reducers/sessionReducer.js
+++ b/client/reducers/sessionReducer.js
@@ -1,50 +1,46 @@
+import update from 'immutability-helper';
 import initialState from './initialState';
-import history from '../history';
 import * as types from '../actions/actionTypes';
 
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 
 export default function sessionReducer(state = initialState.session, action) {
+  let newState = {};
   switch (action.type) {
     case types.LOGIN_SUCCESS:
-      return (Object.assign(
-        {},
-        state,
-        { jwt: !!sessionStorage.jwt },
-        { isAdmin: !!sessionStorage.isAdmin },
-        { userId: !!sessionStorage.userId },
-        { message: action.response.data.message },
-        { isLoading: false }
-      ));
+      newState = update(state, {
+        jwt: { $set: !!sessionStorage.jwt },
+        isAdmin: { $set: !!sessionStorage.isAdmin },
+        userId: { $set: !!sessionStorage.userId },
+        message: { $set: action.response.data.message },
+        isLoading: { $set: false }
+      });
+      return newState;
     case types.LOGIN_FAILURE:
-      history.push('/login');
-      return (Object.assign(
-        {},
-        state,
-        { message: action.response.data.message },
-        { isLoading: false }
-      ));
+      newState = update(state, {
+        message: { $set: action.response.data.message },
+        isLoading: { $set: false }
+      });
+      return newState;
     case types.LOGIN_REQUEST:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: true }
-      ));
+      newState = update(state, {
+        isLoading: { $set: true }
+      });
+      return newState;
     case types.LOGOUT_SUCCESS:
-      return (Object.assign(
-        {},
-        state,
-        { jwt: !!sessionStorage.jwt },
-        { isAdmin: !!sessionStorage.isAdmin },
-        { userId: !!sessionStorage.userId },
-        { isLoading: false }
-      ));
+
+      newState = update(state, {
+        jwt: { $set: !!sessionStorage.jwt },
+        isAdmin: { $set: !!sessionStorage.isAdmin },
+        userId: { $set: !!sessionStorage.userId },
+        isLoading: { $set: false }
+      });
+      return newState;
     case types.LOGOUT_LOADING:
-      return (Object.assign(
-        {},
-        state,
-        { isLoading: true }
-      ));
+      newState = update(state, {
+        isLoading: { $set: false }
+      });
+      return newState;
     default:
       return state;
   }


### PR DESCRIPTION
#### What does this PR do?
Move `history` calls from reducers to components
#### Description of Task to be completed?
* Remove `history` calls from reducers
* Move `history` calls to relevant components
* Remove `Object.assign` calls from reducers
* Use the `update` method from the `immutability-helper` package to create new copies of state
#### How should this be manually tested?
App should work as expected
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#156424976