### PR TITLE
#156827280 Avoid adding events if date passed

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-api: nodemon --exec npm run babel-node ./server/bin/www
-web: webpack-dev-server
+web: nodemon --exec npm run babel-node ./server/bin/www
+react: webpack-dev-server

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -99,7 +99,7 @@ module.exports = {
                     } else if (Date.parse(date) > Date.parse(new Date(req.body.date))) {
                       res.status(403).send({
                         success: false,
-                        message: 'You entered a date that has already passed'
+                        message: 'You likely entered a date that has already passed. Please enter another'
                       });
                     } else {
                       Event
@@ -287,12 +287,23 @@ module.exports = {
                                       });
                                     } else if (center) {
                                       const dates = center.events.map(anEvent => anEvent.date);
+                                      const todayDate = new Date();
+                                      const month = todayDate.getMonth() + 1;
+                                      const day = todayDate.getDay();
+                                      const year = todayDate.getFullYear();
+                                      const date = new Date(year, month, day);
                                       if (
                                         dates.map(Number).indexOf(+(new Date(req.body.date))) !== -1
                                       ) {
                                         res.status(409).send({
                                           success: false,
                                           message: 'Oops. Date has already been taken'
+                                        });
+                                      } else if (
+                                        Date.parse(date) > Date.parse(new Date(req.body.date))) {
+                                        res.status(403).send({
+                                          success: false,
+                                          message: 'You likely entered a date that has already passed. Please enter another'
                                         });
                                       } else {
                                         Event

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -75,6 +75,11 @@ module.exports = {
               });
             } else if (center) {
               const dates = center.events.map(event => event.date);
+              const todayDate = new Date();
+              const month = todayDate.getMonth() + 1;
+              const day = todayDate.getDay();
+              const year = todayDate.getFullYear();
+              const date = new Date(year, month, day);
               if (dates.map(Number).indexOf(+new Date(req.body.date)) !== -1) {
                 res.status(409).send({
                   success: false,
@@ -90,6 +95,11 @@ module.exports = {
                       res.status(409).send({
                         success: false,
                         message: 'Event name already exists'
+                      });
+                    } else if (Date.parse(date) > Date.parse(new Date(req.body.date))) {
+                      res.status(403).send({
+                        success: false,
+                        message: 'You entered a date that has already passed'
                       });
                     } else {
                       Event

--- a/server/schemas/datePassedEvent.js
+++ b/server/schemas/datePassedEvent.js
@@ -1,0 +1,10 @@
+const datePassedEventDB = {
+  name: 'kachi\'s newb third event',
+  detail: 'Awesome event',
+  guests: 1000,
+  date: '2016-11-2',
+  categoryId: 1,
+  centerId: 1
+};
+
+module.exports = datePassedEventDB;

--- a/server/schemas/editEventDB.js
+++ b/server/schemas/editEventDB.js
@@ -2,7 +2,7 @@ const editEventDB = {
   name: 'kachi\'s ultra third event',
   detail: 'Awesome event',
   guests: 1000,
-  date: '2018-11-2',
+  date: '2019-11-2',
   categoryId: 1,
   centerId: 1
 };

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import app from '../../app';
 import newEventDB from '../../schemas/newEventDB';
 import editEventDB from '../../schemas/editEventDB';
+import datePassedEventDB from '../../schemas/datePassedEvent';
 import './initialize';
 
 // const { sequelize } = db;
@@ -65,6 +66,18 @@ describe('Events endpoints', () => {
           err.body.should.be.an('object');
         })
     ));
+    it('should return a 403 if the date entered has passed', () => {
+      request(app)
+        .post('/api/v2/events')
+        .set('x-access-token', token)
+        .send(datePassedEventDB)
+        .expect(403)
+        .then((res) => {
+          res.should.have.status(403);
+          res.body.should.have.property('message');
+          res.body.message.should.equal('You likely entered a date that has already passed. Please enter another');
+        });
+    });
   });
   describe('PUT /events/<eventId>', () => {
     it('should return a 200 if the update is successful', () => (
@@ -140,6 +153,18 @@ describe('Events endpoints', () => {
           err.should.have.status(403);
         })
     ));
+    it('should return a 403 if the date entered has passed', () => {
+      request(app)
+        .put('/api/v2/events/1')
+        .set('x-access-token', token)
+        .send(datePassedEventDB)
+        .expect(403)
+        .then((res) => {
+          res.should.have.status(403);
+          res.body.should.have.property('message');
+          res.body.message.should.equal('You likely entered a date that has already passed. Please enter another');
+        });
+    });
     it('should return a 403 if an authorized user tries to edit an event', () => (
       request(app)
         .post('/api/v2/users/login')


### PR DESCRIPTION
#### What does this PR do?
avoid saving or updating events if date entered has passed
#### Description of Task to be completed?
* check that the date entered hasn't passed before creating an event
* check that the date entered hasn't passed before updating an event
#### How should this be manually tested?
* clone this repo
*`cd` into the project folder
* run `npm install` to install all dependencies
* send a `POST` request to `http://127.0.0.1/api/v2/events` with a payload containing the following - `name, detail, guests, date, centerId, categoryId`, where date is any date in the past
* you should get a response containing a message notifying you that the date has already passed
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#156827280