### PR TITLE
#156950844 Don't save events if guest number greater than center's capacity

### DIFF
--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -101,6 +101,11 @@ module.exports = {
                         success: false,
                         message: 'You likely entered a date that has already passed. Please enter another'
                       });
+                    } else if (req.body.guests > center.capacity) {
+                      res.status(403).send({
+                        success: false,
+                        message: 'The center you selected cannot accomodate the number of guests you entered. Please select another'
+                      });
                     } else {
                       Event
                         .create({
@@ -304,6 +309,11 @@ module.exports = {
                                         res.status(403).send({
                                           success: false,
                                           message: 'You likely entered a date that has already passed. Please enter another'
+                                        });
+                                      } else if (req.body.guests > center.capacity) {
+                                        res.status(403).send({
+                                          success: false,
+                                          message: 'The center you selected cannot accomodate the number of guests you entered. Please select another'
                                         });
                                       } else {
                                         Event

--- a/server/schemas/moreGuestsEventsDB.js
+++ b/server/schemas/moreGuestsEventsDB.js
@@ -1,0 +1,10 @@
+const moreGuestsEventsDB = {
+  name: 'we exist in your dreams',
+  detail: 'Awesome event',
+  guests: 1000000000,
+  date: '2020-11-2',
+  categoryId: 1,
+  centerId: 1
+};
+
+module.exports = moreGuestsEventsDB;

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -4,6 +4,7 @@ import app from '../../app';
 import newEventDB from '../../schemas/newEventDB';
 import editEventDB from '../../schemas/editEventDB';
 import datePassedEventDB from '../../schemas/datePassedEvent';
+import moreGuestsEventsDB from '../../schemas/moreGuestsEventsDB';
 import './initialize';
 
 // const { sequelize } = db;
@@ -76,6 +77,18 @@ describe('Events endpoints', () => {
           res.should.have.status(403);
           res.body.should.have.property('message');
           res.body.message.should.equal('You likely entered a date that has already passed. Please enter another');
+        });
+    });
+    it('should return a 403 if the number of guests is more than the center\'s capacity', () => {
+      request(app)
+        .post('/api/v2/events')
+        .set('x-access-token', token)
+        .send(moreGuestsEventsDB)
+        .expect(403)
+        .then((res) => {
+          res.should.have.status(403);
+          res.body.should.have.property('message');
+          res.body.message.should.equal('The center you selected cannot accomodate the number of guests you entered. Please select another');
         });
     });
   });
@@ -165,6 +178,18 @@ describe('Events endpoints', () => {
           res.body.message.should.equal('You likely entered a date that has already passed. Please enter another');
         });
     });
+    it('should return a 403 if the number of guests is more than the center\'s capacity', () => {
+      request(app)
+        .put('/api/v2/events/1')
+        .set('x-access-token', token)
+        .send(moreGuestsEventsDB)
+        .expect(403)
+        .then((res) => {
+          res.should.have.status(403);
+          res.body.should.have.property('message');
+          res.body.message.should.equal('The center you selected cannot accomodate the number of guests you entered. Please select another');
+        });
+    });
     it('should return a 403 if an authorized user tries to edit an event', () => (
       request(app)
         .post('/api/v2/users/login')
@@ -233,9 +258,9 @@ describe('Events endpoints', () => {
           res.body.event.should.have.property('Center').should.be.an('object');
           res.body.event.should.be.an('object');
         })
-        .catch((err) => {
-          console.log(err);
-        })
+        // .catch((err) => {
+        //   console.log(err);
+        // })
     ));
     it('should return 404, if the id is doesn\'t exist', () => (
       request(app)


### PR DESCRIPTION
#### What does this PR do?
Only save events if the number of guests specified is less than or equal to the center's capacity that was selected
#### Description of Task to be completed?
* Add a condition that ensures that a new center is only created if the number of guests specified is less than the capacity of the center that was selected.
* Add a condition that ensures that an existing center is only updated if the number of guests specified is less than the capacity of the center that was selected.
* Add tests for both methods
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run npm install to install all dependencies
* send a POST request to `http://127.0.0.1/api/v2/users` with a payload containing  the following - `name, email, password`
* send a POST request to `http://127.0.0.1/api/v2/users/login` with a payload containing the `email and password` you entered above
* insert a row into the categories table with any name
* send a POST request to `http://127.0.0.1/api/v2/centers` with a payload containing the following - `name, address, state, detail, capacity, chairs, projector, image`
* send a POST request to http://127.0.0.1/api/v2/events with a payload containing the following - `name, detail, guests, date, centerId, categoryId` where `centerId` and  `categoryId` are `1`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#156950844