### PR TITLE
#157002725 Use generic messages for failed login attempts

### DIFF
--- a/server/controllers/v2/users.js
+++ b/server/controllers/v2/users.js
@@ -121,16 +121,16 @@ module.exports = {
     })
       .then((user) => {
         if (!user) {
-          res.status(404).send({
+          res.status(401).send({
             success: false,
-            message: 'User not found'
+            message: 'Invalid email/password'
           });
         } else if (user) {
           bcrypt.compare(req.body.password, user.password, (err, hash) => {
             if (!hash) {
-              res.status(400).send({
+              res.status(401).send({
                 success: false,
-                message: 'Password mismatch'
+                message: 'Invalid email/password'
               });
             } else if (hash) {
               const payload = {

--- a/server/test/v2/usersTest.js
+++ b/server/test/v2/usersTest.js
@@ -58,7 +58,7 @@ describe('/Users', () => {
           err.should.have.status(400);
         })
     ));
-    it('should return a 404 if the user isn\'t found', () => (
+    it('should return a 401 if the user isn\'t found', () => (
       chai.request(app)
         .post('/api/v2/users/login')
         .send({
@@ -66,7 +66,22 @@ describe('/Users', () => {
           password: 'thththt'
         })
         .catch((err) => {
-          err.should.have.status(404);
+          err.should.have.status(401);
+          err.response.body.should.have.property('message');
+          err.response.body.message.should.equal('Invalid email/password');
+        })
+    ));
+    it('should return a 401 if the email is wrong', () => (
+      chai.request(app)
+        .post('/api/v2/users/login')
+        .send({
+          email: 'kachi@kachi.com',
+          password: 'thththt'
+        })
+        .catch((err) => {
+          err.should.have.status(401);
+          err.response.body.should.have.property('message');
+          err.response.body.message.should.equal('Invalid email/password');
         })
     ));
   });


### PR DESCRIPTION
#### What does this PR do?
use generic messages for failed login attempts
#### Description of Task to be completed?
* use generic messages for failed login attempts
* write tests to ensure that generic messages are returned for failed login attempts
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run npm install to install all dependencies
* send a POST request to http://127.0.0.1/api/v2/users with a payload containing the following - `name, email, password`
* send a POST request to http://127.0.0.1/api/v2/users/login with a payload containing the email and and a different password from what you entered above
* send a POST request to http://127.0.0.1/api/v2/users/login with a payload containing a wrong email and and the right password you entered above
#### Any background context you want to provide?
error messages used to be specific
#### What are the relevant pivotal tracker stories?(if applicable)
#157002725