### PR TITLE
#157126440 Paginate events for a particular center

### DIFF
--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -163,9 +163,6 @@ module.exports = {
     Center
       .findOne({
         where: { id: parseInt(req.params.centerId, 10) },
-        include: [
-          { model: Event, as: 'events' }
-        ]
       })
       .then((center) => {
         if (!center) {

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -548,6 +548,51 @@ module.exports = {
     //   });
     // });
   },
+  getEventsInCenter(req, res) {
+    const { centerId } = req.params;
+    const { limit = 9 } = req.query;
+    const { page = 1 } = req.query;
+    let offset = 0;
+    Event.findAndCountAll({
+      where: { centerId }
+    })
+      .then((data) => {
+        const pages = Math.ceil(data.count / limit);
+        offset = limit * (page - 1);
+        Event.findAll({
+          where: { centerId },
+          limit,
+          offset,
+          order: [
+            ['id', 'ASC']
+          ]
+        })
+          .then((events) => {
+            const next = parseInt(page, 10) + 1;
+            let prev = 1;
+            if (page > 1) {
+              prev = page - 1;
+            }
+            res.status(200).send({
+              success: true,
+              data: {
+                events
+              },
+              meta: {
+                pagination: {
+                  limit,
+                  offset,
+                  page,
+                  pages,
+                  total: data.count,
+                  prev: `http://localhost:8000/api/v2/center/:centerId/events?page=${prev}`,
+                  next: `http://localhost:8000/api/v2/center/:centerId/events?page=${next}`
+                }
+              }
+            });
+          });
+      });
+  },
   /**
   * @swagger
   * /api/v2/events/:

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,6 +17,7 @@ import centerDBSchema from '../validators/centerDBSchema';
 import eventDBSchema from '../validators/eventDBSchema';
 import eventDBWithParams from '../validators/eventDBWithParams';
 import eventDBWithIdSchema from '../validators/eventsDBWithId';
+import eventsInCenterSchema from '../validators/eventsInCenterValidators';
 
 const eventsController = require('../controllers/v1').events;
 const centersController = require('../controllers/v1').centers;
@@ -69,6 +70,7 @@ module.exports = (app) => {
   app.post('/api/v2/events', expressJoi(eventDBSchema), apiRoutes, eventsDBController.create);
   app.put('/api/v2/events/:eventId', expressJoi(eventDBWithParams), apiRoutes, eventsDBController.edit);
   app.get('/api/v2/events', eventsDBController.getAllEvents);
+  app.get('/api/v2/centers/:centerId/events', expressJoi(eventsInCenterSchema), eventsDBController.getEventsInCenter);
   app.get('/api/v2/events/:eventId', expressJoi(eventDBWithIdSchema), eventsDBController.getSingleEvent);
   app.delete('/api/v2/events/:eventId', expressJoi(eventDBWithIdSchema), apiRoutes, eventsDBController.delete);
   app.get('/sign-s3', utilitiesController.signS3);

--- a/server/seeders/20180424130930-test-centers.js
+++ b/server/seeders/20180424130930-test-centers.js
@@ -13,7 +13,104 @@ module.exports = {
       state: 'state',
       createdAt: new Date(),
       updatedAt: new Date()
-    }], {});
+    },
+    {
+      name: 'Second Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Third Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Fourth Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Fifth Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Sixth Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Seventh Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Eigth Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Ninth Centerrry',
+      detail: 'We exist',
+      image: 'ramsey.jpg',
+      address: 'somewhere in lagos',
+      chairs: 10,
+      projector: 1,
+      capacity: 1000,
+      state: 'state',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+    ], {});
   },
 
   down: (queryInterface, Sequelize) => {

--- a/server/seeders/20180424130947-test-events.js
+++ b/server/seeders/20180424130947-test-events.js
@@ -11,7 +11,118 @@ module.exports = {
       centerId: 1,
       createdAt: new Date(),
       updatedAt: new Date()
-    }], {});
+    },
+    {
+      name: 'First event',
+      date: '2020-01-02',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Second event',
+      date: '2020-01-03',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Third event',
+      date: '2020-01-04',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Fourth event',
+      date: '2020-01-05',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Fifth event',
+      date: '2020-01-06',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Sixth event',
+      date: '2020-01-07',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Seventh event',
+      date: '2020-01-08',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Eigth event',
+      date: '2020-01-09',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Ninth event',
+      date: '2020-01-10',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Tenth event',
+      date: '2020-01-11',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'Eleventh event',
+      date: '2020-01-12',
+      detail: 'Awesome event',
+      guests: 1000,
+      categoryId: 1,
+      centerId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+    ], {});
   },
 
   down: (queryInterface, Sequelize) => {

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -66,7 +66,7 @@ describe('Centers endpoints', () => {
         .then((res) => {
           res.should.have.status(200);
           res.body.data.centers.should.be.an('array');
-          res.body.data.centers.length.should.equal(2);
+          res.body.data.centers.length.should.equal(9);
           res.body.should.have.property('meta');
           res.body.meta.should.have.property('pagination');
           res.body.meta.pagination.limit.should.equal(9);
@@ -80,8 +80,6 @@ describe('Centers endpoints', () => {
         .get('/api/v2/centers/1')
         .then((res) => {
           res.should.have.status(200);
-          res.body.center.should.have.property('events');
-          res.body.center.events.should.be.an('array');
         })
         .catch((err) => {
           console.log(err);

--- a/server/validators/eventsInCenterValidators.js
+++ b/server/validators/eventsInCenterValidators.js
@@ -1,0 +1,13 @@
+import Joi from 'joi';
+
+const eventsInCenterSchema = {
+  params: {
+    centerId: Joi.number().required()
+  },
+  query: {
+    page: Joi.number().integer().min(1),
+    limit: Joi.number().integer().min(1)
+  }
+};
+
+module.exports = eventsInCenterSchema;


### PR DESCRIPTION
#### What does this PR do?
paginate events for a particular center
#### Description of Task to be completed?
* create new method to retrieve events associated with a particular center
* create a new endpoint that utilizes this method
* write tests for the new endpoint
* add new objects to the seed files used to create new events and centers
* remove eager loading from the method used to fetch a single center
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run npm install to install all dependencies
* send a POST request to http://127.0.0.1/api/v2/users with a payload containing the following - name, email, password
* send a POST request to http://127.0.0.1/api/v2/users/login with a payload containing the email and password you entered above
* insert a row into the categories table with any name
* send a POST request to http://127.0.0.1/api/v2/centers with a payload containing the following - name, address, state, detail, capacity, chairs, projector, image
* send a POST request to http://127.0.0.1/api/v2/events with a payload containing the following - name, guests, centerId, detail, categoryId, date
* send more POST requests to add new events with different names and dates, with centerId of `1` (Add more than 10)
* send a GET request to `http://127.0.0.1/api/v2/centers/1/events` which should return the first nine events
* send a GET request to `http://127.0.0.1/api/v2/centers/1/events?page=2` which should return the next N events, where N = total number of events - 9
* send a GET request to `http://127.0.0.1/api/v2/centers/1/events?limit=4` which should return the first four events
* send a GET request to `http://127.0.0.1/api/v2/centers/1/events?limit=4&page=2` which should return the four events on the second page
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#157126440