### PR TITLE
#157127399 Specify limit

### DIFF
--- a/server/controllers/v2/centers.js
+++ b/server/controllers/v2/centers.js
@@ -222,7 +222,7 @@ module.exports = {
   //     });
   // },
   getAllCenters(req, res) {
-    const limit = 9;
+    const { limit = 9 } = req.query;
     let offset = 0;
     Center.findAndCountAll()
       .then((data) => {

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -585,8 +585,8 @@ module.exports = {
                   page,
                   pages,
                   total: data.count,
-                  prev: `http://localhost:8000/api/v2/center/:centerId/events?page=${prev}`,
-                  next: `http://localhost:8000/api/v2/center/:centerId/events?page=${next}`
+                  prev: `http://localhost:8000/api/v2/centers/${parseInt(centerId, 10)}/events?page=${prev}`,
+                  next: `http://localhost:8000/api/v2/centers/${parseInt(centerId, 10)}/events?page=${next}`
                 }
               }
             });

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -494,7 +494,7 @@ module.exports = {
   */
   /**/
   getAllEvents(req, res) {
-    const limit = 9;
+    const { limit = 9 } = req.query;
     let offset = 0;
     Event.findAndCountAll()
       .then((data) => {

--- a/server/test/v2/centersTest.js
+++ b/server/test/v2/centersTest.js
@@ -80,6 +80,27 @@ describe('Centers endpoints', () => {
           res.should.have.status(400);
         });
     });
+    it('should return the appropriate number of centers for the limit specified', () => {
+      request(app)
+        .get(`/api/v2/centers?limit=${4}`)
+        .then((res) => {
+          res.should.have.status(200);
+          res.body.data.should.have.property('centers');
+          res.body.data.centers.length.should.equal(4);
+          res.body.meta.pagination.limit.should.equal(4);
+        });
+    });
+    it('should start at the right center if the page number is specified', () => {
+      request(app)
+        .get(`/api/v2/centers?limit=${4}&page=${2}`)
+        .then((res) => {
+          res.should.have.status(200);
+          res.body.data.should.have.property('centers');
+          res.body.data.centers.length.should.equal(4);
+          res.body.data.centers[0].id.should.equal(5);
+          res.body.meta.pagination.limit.should.equal(4);
+        });
+    });
   });
 
   describe('GET /api/v2/centers/<centerId>', () => {

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -284,6 +284,16 @@ describe('Events endpoints', () => {
           res.should.have.status(400);
         });
     });
+    it('should return the appropriate number of events for the limit specified', () => {
+      request(app)
+        .get(`/api/v2/events?limit=${4}`)
+        .then((res) => {
+          res.should.have.status(200);
+          res.body.data.should.have.property('events');
+          res.body.data.events.length.should.equal(4);
+          res.body.meta.pagination.limit.should.equal(4);
+        });
+    });
   });
   describe('GET /api/v2/centers/:centerId/events', () => {
     it('should return a 200 and all the events for the center specified', () => {

--- a/server/test/v2/eventsTest.js
+++ b/server/test/v2/eventsTest.js
@@ -294,6 +294,17 @@ describe('Events endpoints', () => {
           res.body.meta.pagination.limit.should.equal(4);
         });
     });
+    it('should start at the right event if the page number is specified', () => {
+      request(app)
+        .get(`/api/v2/events?limit=${4}&page=${2}`)
+        .then((res) => {
+          res.should.have.status(200);
+          res.body.data.should.have.property('events');
+          res.body.data.events.length.should.equal(4);
+          res.body.data.events[0].id.should.equal(6);
+          res.body.meta.pagination.limit.should.equal(4);
+        });
+    });
   });
   describe('GET /api/v2/centers/:centerId/events', () => {
     it('should return a 200 and all the events for the center specified', () => {
@@ -344,8 +355,8 @@ describe('Events endpoints', () => {
         .get(`/api/v2/centers/${1}/events?limit=${4}&page=${2}`)
         .then((res) => {
           res.should.have.status(200);
-          res.body.meta.pagination.prev.should.equal(`http://localhost:8000/api/v2/center/:centerId/events?page=${1}`);
-          res.body.meta.pagination.prev.should.equal(`http://localhost:8000/api/v2/center/:centerId/events?page=${3}`);
+          res.body.meta.pagination.prev.should.equal(`http://localhost:8000/api/v2/centers/${1}/events?page=${1}`);
+          res.body.meta.pagination.next.should.equal(`http://localhost:8000/api/v2/centers/${1}/events?page=${3}`);
         });
     });
   });


### PR DESCRIPTION
#### What does this PR do?
specify limit when fetching centers and events
#### Description of Task to be completed?
* add line that uses the limit in the query object if one is specified
* add tests to ensure that the appropriate number of centers/events if a limit is specified
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run npm install to install all dependencies
* send a POST request to http://127.0.0.1/api/v2/users with a payload containing the following - name, email, password
* send a POST request to http://127.0.0.1/api/v2/users/login with a payload containing the email and password you entered above
* insert a row into the categories table with any name
* send a POST request to http://127.0.0.1/api/v2/centers with a payload containing the following - name, address, state, detail, capacity, chairs, projector, image
* send a POST request to http://127.0.0.1/api/v2/events with a payload containing the following - name, guests, centerId, detail, categoryId, date
* send more POST requests to add new events with different names and dates, with centerId of 1 (Add more than 10)
* send a GET request to http://127.0.0.1/api/v2/events?limit=4. You should get 4 events returned
* send a GET request to http://127.0.0.1/api/v2/centers?limit=4. You should get 4 centers returned
* send a GET request to http://127.0.0.1/api/v2/centers/1/events?limit=4. You should get 4 events returned
#### Any background context you want to provide?
initial task was meant to also cover offset but offset is calculated using the page number specified
#### What are the relevant pivotal tracker stories?(if applicable)
#157127399