### PR TITLE
#157507866 Paginate events on frontend

### DIFF
--- a/client/actions/eventActions.js
+++ b/client/actions/eventActions.js
@@ -1,25 +1,25 @@
 import * as types from './actionTypes';
 import EventApi from '../api/eventApi';
 
-export function fetchEventsSuccess(events) {
-  return { type: types.FETCH_EVENTS_SUCCESS, events };
+export function fetchEventsSuccess(data) {
+  return { type: types.FETCH_EVENTS_SUCCESS, data };
 }
-export function fetchEventsFailure(events) {
-  return { type: types.FETCH_EVENTS_FAILURE, events };
+export function fetchEventsFailure() {
+  return { type: types.FETCH_EVENTS_FAILURE };
 }
 export function fetchEventsLoading() {
   return { type: types.FETCH_EVENTS_LOADING };
 }
 
-export function fetchEvents() {
+export function fetchEvents(page) {
   return (dispatch) => {
     dispatch(fetchEventsLoading());
-    return EventApi.getAll()
+    return EventApi.getAll(page)
       .then((response) => {
-        dispatch(fetchEventsSuccess(response.data.events));
+        dispatch(fetchEventsSuccess(response.data));
       })
       .catch((error) => {
-        dispatch(fetchEventsFailure(error.data));
+        dispatch(fetchEventsFailure());
       });
   };
 }

--- a/client/api/eventApi.js
+++ b/client/api/eventApi.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 class EventApi {
-  static getAll() {
+  static getAll(page) {
     return axios.get(
-      'http://localhost:8000/api/v2/events',
+      `http://localhost:8000/api/v2/events?page=${page}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -14,8 +14,8 @@ class EventApi {
         return response;
       })
       .catch((error) => {
-        console.log('CATCH = ', error.response);
-        throw error.response;
+        console.log('CATCH = ', error);
+        return error.response;
       })
   }
   static getOne(eventId) {

--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -16,7 +16,6 @@ export class Home extends React.Component {
   componentDidMount() {
     // $('.parallax').parallax();
     const values = qs.parse(this.props.location.search);
-    console.log(values)
     let page;
     if (values.page === undefined) {
       page = 1;
@@ -27,7 +26,7 @@ export class Home extends React.Component {
       this.props.actions.fetchCenters(page);
     }
     if (this.props.events.length === 0) {
-      this.props.actions.fetchEvents();
+      this.props.actions.fetchEvents(page);
     }
   }
   render() {

--- a/client/components/centers/containers/Centers.jsx
+++ b/client/components/centers/containers/Centers.jsx
@@ -65,12 +65,14 @@ export class Centers extends Component {
           <div className="row">
             <CenterList centers={centers} isAdmin={isAdmin} />
           </div>
-          <Pagination
-            items={9}
-            activePage={this.state.page}
-            onSelect={this.changePage}
-            maxButtons={pages}
-          />
+          { pages !== 1 ? (
+            <Pagination
+              items={9}
+              activePage={this.state.page}
+              onSelect={this.changePage}
+              maxButtons={pages}
+            />
+          ) : ''}
         </div>
         <div className="fixed-action-btn horizontal click-to-toggle">
           <Link

--- a/client/reducers/eventReducer.js
+++ b/client/reducers/eventReducer.js
@@ -33,14 +33,21 @@ export default function eventReducer(state = initialState.events, action) {
     case types.FETCH_EVENTS_SUCCESS:
       theState = update(state, {
         events: {
-          $set: action.events
+          $set: action.data.data.events
+        },
+        meta: {
+          pagination: {
+            limit: { $set: action.data.meta.pagination.limit },
+            page: { $set: action.data.meta.pagination.page },
+            pages: { $set: action.data.meta.pagination.pages },
+            total: { $set: action.data.meta.pagination.total }
+          }
         },
         isLoading: { $set: false }
       });
       return theState;
     case types.FETCH_EVENTS_FAILURE:
       theState = update(state, {
-        message: { $set: action.events.message },
         isLoading: { $set: false }
       });
       return theState;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -28,7 +28,16 @@ export default {
   events: {
     events: [],
     isLoading: false,
-    message: ''
+    message: '',
+    meta: {
+      pagination: {
+        limit: '',
+        offset: '',
+        page: '',
+        pages: '',
+        total: ''
+      }
+    }
   },
   center: {},
   event: {},


### PR DESCRIPTION
#### What does this PR do?
paginate events on the frontend part of my project
#### Description of Task to be completed?
* add pagination component to Events container
* get the page number from the query params or specify a default page number
* create a changePage method that calls the fetchEvents action and passes the page number as its argument
* modify the url in the events api class to make use of the page number from the component
* modify the action and action creator for fetching events to make use of the page number
* modify the payload passed with the action to make use of the new api response format
* modify the reducer method that's called for retrieving events to make use of the modified payload
* add a meta object with pagination details to the events object in initial state
only show the pagination component when there are more than 1 page for both events and centers
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `npm install` to install all dependecies
* run `npm run start:all` to start up the application
* go to localhost:8080 on your browser
* click on `Signup`
* enter your details
* click on `Signup`
* request for admin access
* click on `Centers` on the navbar
* click on the red add button at the bottom right corner
* enter the details of the center
* click on `Add Center`
* add at least ten more centers
* click on `Centers`
* click on `Events`
* click on the red add button at the bottom right corner
* enter the details of the event
* click on `Add Event`
* add at least ten more events
* click on `Events` on the navbar
* you should see a pagination link at the bottom of the page
#### Any background context you want to provide?
this feature will break pending when the flow for adding new events is changed
#### What are the relevant pivotal tracker stories?(if applicable)
#157507866