### PR TITLE
#157637685 create events from a center's page

### DIFF
--- a/client/components/centers/containers/SingleCenter.jsx
+++ b/client/components/centers/containers/SingleCenter.jsx
@@ -2,8 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import EventsListWithImage from '../../events/presentational/EventsListWithImage';
 import CenterDetail from '../presentational/CenterDetail';
+import AddEvent from '../../events/container/AddEvent';
 import * as singleCenterActions from '../../../actions/singleCenterActions';
 import * as styles from '../../../css/centers.module.css';
 
@@ -14,10 +16,13 @@ export class SingleCenter extends Component {
   //   }
   // }
   componentDidMount() {
+    $('.modal').modal();
     this.props.singleCenterActions.fetchSingleCenter(parseInt(this.props.match.params.id, 10));
   }
   render() {
+    const { center = {} } = this.props;
     const { events = [] } = this.props.center;
+    const modalClasses = classNames('modal', styles['add-event-modal']);
     return (
       <div className="min-height-hundred-vh">
         <div className="valign-wrapper show-center-top">
@@ -32,6 +37,19 @@ export class SingleCenter extends Component {
               events={events}
               isAdmin={false}
             />
+          </div>
+        </div>
+        <div className="fixed-action-btn horizontal click-to-toggle">
+          <a
+            href="#addEventModal"
+            className="btn-floating btn-large red white-color modal-trigger"
+          >
+            <i className="material-icons">add</i>
+          </a>
+        </div>
+        <div className={modalClasses} id="addEventModal">
+          <div className="modal-content">
+            <AddEvent centerId={center.id} />
           </div>
         </div>
       </div>

--- a/client/components/centers/presentational/CenterDetail.jsx
+++ b/client/components/centers/presentational/CenterDetail.jsx
@@ -5,10 +5,10 @@ import * as styles from '../../../css/centers.module.css';
 const CenterDetail = ({ center }) => (
   <div className="center-detail-container">
     <div className="row">
-      <div className="col s8 l8 m8">
+      <div className="col s12 l8 m12">
         <img src={center.image} alt={`${center.name}`} className={styles['show-center-image']} />
       </div>
-      <div className="col s4 l4 m4">
+      <div className="col s12 l4 m12">
         <h1>{center.name}</h1>
         <React.Fragment>
           <p className={styles.tiny}>

--- a/client/components/events/container/AddEvent.jsx
+++ b/client/components/events/container/AddEvent.jsx
@@ -10,7 +10,6 @@ import MenuItem from 'material-ui/MenuItem';
 import * as eventActions from '../../../actions/eventActions';
 import * as centerActions from '../../../actions/centerActions';
 import EventsForm from '../presentational/EventsForm';
-import history from '../../../history';
 
 export class AddEvent extends Component {
   constructor(props) {
@@ -33,9 +32,9 @@ export class AddEvent extends Component {
     this.addEvent = this.addEvent.bind(this);
   }
   componentDidMount() {
-    if (this.props.centers.length === 0) {
-      this.props.actions.fetchCenters();
-    }
+    // if (this.props.centers.length === 0) {
+    //   this.props.actions.fetchCenters();
+    // }
     $('.datepicker').pickadate({
       selectMonths: true, // Creates a dropdown to control month
       selectYears: 15, // Creates a dropdown of 15 years to control year,
@@ -43,7 +42,8 @@ export class AddEvent extends Component {
       clear: 'Clear',
       close: 'Ok',
       closeOnSelect: true, // Close upon selecting a date,
-      onSet: this.handleDateChange
+      onSet: this.handleDateChange,
+      container: 'body'
     });
     const time = $('#event-time');
     // const value = $('#event-time').attr('value');
@@ -57,6 +57,7 @@ export class AddEvent extends Component {
       autoclose: false, // automatic close timepicker
       ampmclickable: true, // make AM PM clickable
       aftershow: () => {},
+      container: 'body'
     });
     $('.timepicker').on('change', () => {
       this.handleTimeChange(time.val());
@@ -188,7 +189,6 @@ export class AddEvent extends Component {
     this.setState({ date: { value: '', isValid: true, message: '' } });
     this.setState({ time: { value: '', isValid: true, message: '' } });
     this.setState({ detail: { value: '', isValid: true, message: '' } });
-    this.setState({ center: { value: '', isValid: true, message: '' } });
     this.setState({ category: { value: '', isValid: true, message: '' } });
   }
   addEvent(e) {
@@ -200,14 +200,15 @@ export class AddEvent extends Component {
       detail: this.state.detail.value,
       guests: this.state.guests.value,
       date: moment(datetime).format('YYYY-MM-DD HH:mm:ss'),
-      centerId: this.state.center.value,
+      centerId: this.props.centerId,
       categoryId: this.state.category.value
     };
     if (this.formIsValid()) {
       this.props.actions.addEvent(eventObject)
         .then((response) => {
           Materialize.toast(response, 4000, 'green');
-          history.push('/events');
+          this.clearFields();
+          $('#addEventModal').modal('close');
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
@@ -224,7 +225,7 @@ export class AddEvent extends Component {
     const containerClasses = classNames('container max-width-six-hundred');
     return (
       <div className={containerClasses}>
-        <div className="card">
+        <div>
           <div className="container">
             <h3 className="center-heading">Add an Event</h3>
           </div>
@@ -259,7 +260,11 @@ export class AddEvent extends Component {
 }
 AddEvent.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
-  centers: PropTypes.arrayOf(PropTypes.object).isRequired
+  centers: PropTypes.arrayOf(PropTypes.object).isRequired,
+  centerId: PropTypes.number
+};
+AddEvent.defaultProps = {
+  centerId: 1
 };
 function mapStateToProps(state) {
   let centers = [];

--- a/client/components/events/presentational/EventsForm.jsx
+++ b/client/components/events/presentational/EventsForm.jsx
@@ -8,7 +8,7 @@ const EventsForm = ({
   handleTimeChange, handleSelectCenterChange, handleSelectCategoryChange,
   SelectField, MenuItem
 }) => (
-  <form className="card-content">
+  <form>
     <div className="row">
       <div className="input-field col s12">
         <input
@@ -61,66 +61,7 @@ const EventsForm = ({
         )}
         <span className={guestsClasses}>{guests.message}</span>
       </div>
-    </div>
-    <div className="row">
-      <div className="input-field col s12">
-        <input
-          name="date"
-          value={date.value}
-          type="text"
-          className="datepicker"
-          id="event-date"
-        />
-        { component !== 'Edit' ? (
-          <label htmlFor="event-date">Date</label>
-        ) : (
-          <label htmlFor="event-date" className="active">Date</label>
-        )}
-        <span className={dateClasses}>{date.message}</span>
-      </div>
-    </div>
-    <div className="row">
-      <div className="input-field col s12">
-        <input
-          id="event-time"
-          name="time"
-          value={time.value}
-          className="timepicker"
-          type="text"
-          onChange={handleTimeChange}
-        />
-        { component !== 'Edit' ? (
-          <label htmlFor="event-time">Time</label>
-        ) : (
-          <label htmlFor="event-time" className="active">Time</label>
-        )}
-        <span className={timeClasses}>{time.message}</span>
-      </div>
-    </div>
-    <div className="row">
       <div className="input-field col s6">
-        <SelectField
-          name="center"
-          value={parseInt(center.value, 10)}
-          onChange={handleSelectCenterChange}
-          id="event-center"
-        >
-          {centers.map(aCenter => (
-            <MenuItem
-              key={aCenter.id}
-              value={aCenter.id}
-              primaryText={aCenter.name}
-            />
-          ))}
-        </SelectField>
-        { component !== 'Edit' ? (
-          <label htmlFor="event-center" className="active">Center</label>
-        ) : (
-          <label htmlFor="event-center" className="active">Center</label>
-        )}
-        <span className={centerClasses}>{center.message}</span>
-      </div>
-      <div className="input-field col s16">
         <select
           name="category"
           value={category.value}
@@ -131,6 +72,41 @@ const EventsForm = ({
         </select>
         <label htmlFor="event-category">Category</label>
         <span className={categoryClasses}>{category.message}</span>
+      </div>
+    </div>
+    <div className="row">
+      <div className="input-field col s12">
+        <div className="input-field col s6">
+          <input
+            name="date"
+            value={date.value}
+            type="text"
+            className="datepicker"
+            id="event-date"
+          />
+          { component !== 'Edit' ? (
+            <label htmlFor="event-date">Date</label>
+          ) : (
+            <label htmlFor="event-date" className="active">Date</label>
+          )}
+          <span className={dateClasses}>{date.message}</span>
+        </div>
+        <div className="input-field col s6">
+          <input
+            id="event-time"
+            name="time"
+            value={time.value}
+            className="timepicker"
+            type="text"
+            onChange={handleTimeChange}
+          />
+          { component !== 'Edit' ? (
+            <label htmlFor="event-time">Time</label>
+          ) : (
+            <label htmlFor="event-time" className="active">Time</label>
+          )}
+          <span className={timeClasses}>{time.message}</span>
+        </div>
       </div>
     </div>
     <div className="row center-align">

--- a/client/css/centers.module.css
+++ b/client/css/centers.module.css
@@ -164,4 +164,10 @@ a, a:link, a:visited, a:active {
   width: 800px;
   height: auto;
   margin-left: -11px;
+  max-height: 100%;
+  max-width: 100%
+}
+.add-event-modal {
+  max-height: 100% !important;
+  bottom: 5%;
 }

--- a/client/reducers/eventReducer.js
+++ b/client/reducers/eventReducer.js
@@ -87,13 +87,13 @@ export default function eventReducer(state = initialState.events, action) {
       theState = update(state, {
         events: { $set: addEventReducer(state.events, action) },
         isLoading: { $set: false },
-        message: { $set: action.event.message }
+        // message: { $set: action.event.message }
       });
       return theState;
     case types.ADD_EVENT_FAILURE:
       theState = update(state, {
         isLoading: { $set: false },
-        message: { $set: action.event.data.message }
+        // message: { $set: action.event.data.message }
       });
       return theState;
     default:

--- a/server/controllers/v2/events.js
+++ b/server/controllers/v2/events.js
@@ -102,7 +102,8 @@ module.exports = {
                         success: false,
                         message: 'You entered an invalid date'
                       });
-                    } else if (Date.parse(date) > Date.parse(new Date(req.body.date))) {
+                    } else if (Date.parse(todayDate) > Date.parse(new Date(req.body.date))) {
+                      console.log([todayDate, new Date(req.body.date)]);
                       res.status(403).send({
                         success: false,
                         message: 'You likely entered a date that has already passed. Please enter another'
@@ -321,7 +322,7 @@ module.exports = {
                                           message: 'You entered an invalid date'
                                         });
                                       } else if (
-                                        Date.parse(date) > Date.parse(new Date(req.body.date))) {
+                                        Date.parse(todayDate) > Date.parse(new Date(req.body.date))) {
                                         res.status(403).send({
                                           success: false,
                                           message: 'You likely entered a date that has already passed. Please enter another'


### PR DESCRIPTION
#### What does this PR do?
allow a user create an event from a center's page
#### Description of Task to be completed?
* initialize materialize's modal when mounting the `SingleCenter` component
* import the AddEvent component inside the `SingleCenter` component
* put the AddEvent component inside a modal
* remove the card classes from the EventsForm and AddEvent components
* pass the centerId as a prop to the AddEvent component
* set defaultProps for centerId in the AddEvent component
* remove the centers dropdown in the EventsForm component
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `npm install` to install all dependecies
* run `npm run start:all` to start up the application
* go to `localhost:8080` on your browser
* click on `Signup`
* enter your details
* click on `Signup`
* request for admin access
* click on `Centers`
* click on the red add button at the bottom right corner
* enter the details of the center
* click on Add Center
* you should be taken to the `Centers` page
* select the center
* click on the red floating button at the bottom right of the page to add a new event
* a modal should come up
* enter the event's details
* click on `Add Event`
* you should see a toast telling you that the event has been added
#### Any background context you want to provide?
> events could be created alone in the past and utilized a dropdown that had all the centers in the system, but can't work with paginated requests 
#### What are the relevant pivotal tracker stories?(if applicable)
#157637685