### PR TITLE
#157770713 Fix modals

### DIFF
--- a/client/components/centers/containers/SingleCenter.jsx
+++ b/client/components/centers/containers/SingleCenter.jsx
@@ -20,13 +20,15 @@ export class SingleCenter extends Component {
     this.state = {
       page: 1,
       eventId: '',
-      show: false
+      show: false,
+      editMode: false
     };
     this.changePage = this.changePage.bind(this);
     this.changeEvent = this.changeEvent.bind(this);
     this.deleteEvent = this.deleteEvent.bind(this);
     this.hideModal = this.hideModal.bind(this);
     this.showModal = this.showModal.bind(this);
+    this.toggleEdit = this.toggleEdit.bind(this);
   }
   componentDidMount() {
     $('.modal').modal();
@@ -38,9 +40,15 @@ export class SingleCenter extends Component {
       show: true
     });
   }
+  toggleEdit() {
+    this.setState({
+      editMode: !this.state.editMode
+    });
+  }
   hideModal() {
     this.setState({
-      show: false
+      show: false,
+      editMode: false
     });
   }
   changePage(e) {
@@ -65,7 +73,6 @@ export class SingleCenter extends Component {
     if ((pages) >= 9) {
       pages = 9;
     }
-    const modalClasses = classNames('modal', styles['add-event-modal']);
     return (
       <div className="min-height-hundred-vh">
         <div className="valign-wrapper show-center-top">
@@ -84,6 +91,8 @@ export class SingleCenter extends Component {
                   isAdmin={this.props.isAdmin}
                   changeEvent={this.changeEvent}
                   centerId={center.id}
+                  toggleEdit={this.toggleEdit}
+                  showModal={this.showModal}
                 />
               </div>
             </div>
@@ -119,7 +128,16 @@ export class SingleCenter extends Component {
         </div>
        */ }
         <Modal show={this.state.show} hideModal={this.hideModal}>
-          <AddEvent centerId={center.id} hideModal={this.hideModal} />
+          { !this.state.editMode ? (
+            <AddEvent centerId={center.id} hideModal={this.hideModal} />
+          ) : (
+            <EditEvent
+              centerId={center.id}
+              eventId={this.state.eventId}
+              hideModal={this.hideModal}
+              toggleEdit={this.toggleEdit}
+            />
+          )}
         </Modal>
       </div>
     );

--- a/client/components/centers/containers/SingleCenter.jsx
+++ b/client/components/centers/containers/SingleCenter.jsx
@@ -8,6 +8,7 @@ import EventsListWithImage from '../../events/presentational/EventsListWithImage
 import CenterDetail from '../presentational/CenterDetail';
 import AddEvent from '../../events/container/AddEvent';
 import EditEvent from '../../events/container/EditEvent';
+import Modal from '../../common/Modal';
 import * as singleCenterActions from '../../../actions/singleCenterActions';
 import * as centerActions from '../../../actions/centerActions';
 import * as eventActions from '../../../actions/eventActions';
@@ -18,16 +19,29 @@ export class SingleCenter extends Component {
     super(props);
     this.state = {
       page: 1,
-      eventId: ''
+      eventId: '',
+      show: false
     };
     this.changePage = this.changePage.bind(this);
     this.changeEvent = this.changeEvent.bind(this);
     this.deleteEvent = this.deleteEvent.bind(this);
+    this.hideModal = this.hideModal.bind(this);
+    this.showModal = this.showModal.bind(this);
   }
   componentDidMount() {
     $('.modal').modal();
     this.props.actions.fetchSingleCenter(parseInt(this.props.match.params.id, 10));
     this.props.actions.fetchEventsInCenter(parseInt(this.props.match.params.id, 10), 1);
+  }
+  showModal() {
+    this.setState({
+      show: true
+    });
+  }
+  hideModal() {
+    this.setState({
+      show: false
+    });
   }
   changePage(e) {
     this.setState({
@@ -90,18 +104,23 @@ export class SingleCenter extends Component {
           </div>
         )}
         <div className="fixed-action-btn horizontal click-to-toggle">
-          <a
-            href="#addEventModal"
-            className="btn-floating btn-large red white-color modal-trigger"
+          <button
+            className="btn-floating btn-large red white-color"
+            onClick={this.showModal}
           >
             <i className="material-icons">add</i>
-          </a>
+          </button>
         </div>
-        <div className={modalClasses} id="addEventModal">
+        { /*
+          <div className={modalClasses} id="addEventModal">
           <div className="modal-content">
             <AddEvent centerId={center.id} />
           </div>
         </div>
+       */ }
+        <Modal show={this.state.show} hideModal={this.hideModal}>
+          <AddEvent centerId={center.id} hideModal={this.hideModal} />
+        </Modal>
       </div>
     );
   }

--- a/client/components/common/Modal.jsx
+++ b/client/components/common/Modal.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import classNames from 'classnames';
+import * as styles from '../../css/events.module.css';
+
+const Modal = ({ hideModal, show, children }) => {
+  const showHideClassName = show ? classNames('modal display-block', styles['edit-event-modal']) : 'modal display-none';
+
+  return (
+    <div className={showHideClassName}>
+      <button className={styles.close} onClick={hideModal}>&times;</button>
+      <div className="modal-content">
+        {children}
+      </div>
+    </div>
+  );
+};
+export default Modal;

--- a/client/components/events/container/AddEvent.jsx
+++ b/client/components/events/container/AddEvent.jsx
@@ -30,6 +30,7 @@ export class AddEvent extends Component {
     this.handleSelectCenterChange = this.handleSelectCenterChange.bind(this);
     this.handleSelectCategoryChange = this.handleSelectCategoryChange.bind(this);
     this.addEvent = this.addEvent.bind(this);
+    this.addAndClose = this.addAndClose.bind(this);
   }
   componentDidMount() {
     // if (this.props.centers.length === 0) {
@@ -208,10 +209,13 @@ export class AddEvent extends Component {
         .then((response) => {
           Materialize.toast(response, 4000, 'green');
           this.clearFields();
-          $('#addEventModal').modal('close');
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
+  }
+  addAndClose(e) {
+    this.addEvent(e);
+    this.props.hideModal();
   }
   render() {
     const { centers = [] } = this.props;
@@ -244,7 +248,7 @@ export class AddEvent extends Component {
             centerClasses={centerClasses}
             categoryClasses={categoryClasses}
             detailClasses={detailClasses}
-            saveOrUpdate={this.addEvent}
+            saveOrUpdate={this.addAndClose}
             handleChange={this.handleChange}
             handleTimeChange={this.handleTimeChange}
             handleSelectCenterChange={this.handleSelectCenterChange}

--- a/client/components/events/container/AddEvent.jsx
+++ b/client/components/events/container/AddEvent.jsx
@@ -30,7 +30,6 @@ export class AddEvent extends Component {
     this.handleSelectCenterChange = this.handleSelectCenterChange.bind(this);
     this.handleSelectCategoryChange = this.handleSelectCategoryChange.bind(this);
     this.addEvent = this.addEvent.bind(this);
-    this.addAndClose = this.addAndClose.bind(this);
   }
   componentDidMount() {
     // if (this.props.centers.length === 0) {
@@ -209,13 +208,10 @@ export class AddEvent extends Component {
         .then((response) => {
           Materialize.toast(response, 4000, 'green');
           this.clearFields();
+          this.props.hideModal()
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
-  }
-  addAndClose(e) {
-    this.addEvent(e);
-    this.props.hideModal();
   }
   render() {
     const { centers = [] } = this.props;
@@ -248,7 +244,7 @@ export class AddEvent extends Component {
             centerClasses={centerClasses}
             categoryClasses={categoryClasses}
             detailClasses={detailClasses}
-            saveOrUpdate={this.addAndClose}
+            saveOrUpdate={this.addEvent}
             handleChange={this.handleChange}
             handleTimeChange={this.handleTimeChange}
             handleSelectCenterChange={this.handleSelectCenterChange}
@@ -265,10 +261,12 @@ export class AddEvent extends Component {
 AddEvent.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
   centers: PropTypes.arrayOf(PropTypes.object).isRequired,
-  centerId: PropTypes.number
+  centerId: PropTypes.number,
+  hideModal: PropTypes.func,
 };
 AddEvent.defaultProps = {
-  centerId: 1
+  centerId: 1,
+  hideModal: () => {},
 };
 function mapStateToProps(state) {
   let centers = [];

--- a/client/components/events/container/EditEvent.jsx
+++ b/client/components/events/container/EditEvent.jsx
@@ -90,9 +90,6 @@ export class EditEvent extends Component {
         })
       });
     }
-    if (nextProps.centers.length > 0) {
-      this.setState({ centers: nextProps.centers });
-    }
   }
   handleChange(e) {
     const { state } = this;
@@ -209,20 +206,19 @@ export class EditEvent extends Component {
       this.props.actions.updateEvent(eventObject)
         .then((response) => {
           Materialize.toast(response.message, 4000, 'green');
-          $(`#editEventModal${this.props.eventId}`).modal('close');
+          this.props.toggleEdit();
+          this.props.hideModal();
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
       // this.clearFields();
     }
   }
   render() {
-    const { centers = [] } = this.props;
     const nameClasses = classNames('help-block', { 'has-error': !this.state.name.isValid });
     const detailClasses = classNames('help-block', { 'has-error': !this.state.detail.isValid });
     const guestsClasses = classNames('help-block', { 'has-error': !this.state.guests.isValid });
     const dateClasses = classNames('help-block', { 'has-error': !this.state.date.isValid });
     const timeClasses = classNames('help-block', { 'has-error': !this.state.time.isValid });
-    const centerClasses = classNames('help-block', { 'has-error': !this.state.center.isValid });
     const categoryClasses = classNames('help-block', { 'has-error': !this.state.category.isValid });
     const containerClasses = classNames('container max-width-six-hundred');
     return (
@@ -281,16 +277,18 @@ EditEvent.propTypes = {
     })
   }).isRequired,
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
-  centers: PropTypes.arrayOf(PropTypes.object).isRequired,
   eventId: PropTypes.number,
-  centerId: PropTypes.number
+  centerId: PropTypes.number,
+  toggleEdit: PropTypes.func,
+  hideModal: PropTypes.func
 };
 EditEvent.defaultProps = {
   eventId: 1,
-  centerId: 1
+  centerId: 1,
+  toggleEdit: () => {},
+  hideModal: () => {},
 };
 function mapStateToProps(state) {
-  let centers = [];
   let event = {
     id: '',
     name: '',
@@ -301,15 +299,11 @@ function mapStateToProps(state) {
     date: '',
     Center: {}
   };
-  if (state.event && state.event.id !== '') {
-    ({ event } = state);
-  }
-  if (state.centers.centers && state.centers.centers.length > 0) {
-    ({ centers: { centers } } = state);
+  if (state.events.event && state.events.event.id !== '') {
+    ({ events: { event } } = state);
   }
   return {
     event,
-    centers
   };
 }
 function mapDispatchToProps(dispatch) {

--- a/client/components/events/presentational/EventsListWithImage.jsx
+++ b/client/components/events/presentational/EventsListWithImage.jsx
@@ -2,64 +2,51 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
-import classNames from 'classnames';
 import * as styles from '../../../css/events.module.css';
-import EditEvent from '../container/EditEvent';
 import owenShaw from '../../../img/owen shaw.jpg';
 
 const EventsListWithImage = ({
-  events, isAdmin, loggedIn, deleteEvent, changeEvent, centerId
-}) => {
-  const modalClasses = classNames('modal', styles['edit-event-modal']);
-  return (
-    <div>
-      {events.map(event => (
-        <div key={event.id}>
-          <div className="col s12 m6 l4 hvr-grow">
-            <div className="card z-depth-2">
-              <Link to={`/events/${event.id}`}>
-                <div className="card-image">
-                  <img src={owenShaw} alt={`${event.name}`} className="event-image" />
-                </div>
-                <div className="card-content">
-                  <span className={styles['event-focus']}>{event.name}</span><br />
-                  <span className={styles['event-date']}>{moment(event.date).format('LL')}</span><br />
-                  <span className={styles['fifteen-percent']}>{moment(event.date).format('LT')}</span>
-                </div>
-              </Link>
-              { isAdmin || loggedIn ? (
-                <div className="card-action">
-                  <React.Fragment>
-                    <button
-                      href={`#editEventModal${event.id}`}
-                      onClick={() => changeEvent(event.id)}
-                      className="waves-effect waves-light btn navbar-purple round-btn white-color left-align modal-trigger"
-                    >
-                      <i className="material-icons">edit</i>
-                    </button>
-                    <button
-                      onClick={() => deleteEvent(event.id)}
-                      className="waves-effect waves-light btn navbar-purple round-btn white-color right"
-                    >
-                      <i className="material-icons">delete</i>
-                    </button>
-                  </React.Fragment>
-                </div>
-              ) : (
-                <React.Fragment />
-              )}
+  events, isAdmin, loggedIn, deleteEvent, changeEvent, centerId, toggleEdit, showModal
+}) => (
+  <div>
+    {events.map(event => (
+      <div className="col s12 m6 l4 hvr-grow" key={event.id}>
+        <div className="card z-depth-2">
+          <Link to={`/events/${event.id}`}>
+            <div className="card-image">
+              <img src={owenShaw} alt={`${event.name}`} className="event-image" />
             </div>
-          </div>
-          <div className={modalClasses} id={`editEventModal${event.id}`}>
-            <div className="modal-content">
-              <EditEvent eventId={event.id} centerId={centerId} />
+            <div className="card-content">
+              <span className={styles['event-focus']}>{event.name}</span><br />
+              <span className={styles['event-date']}>{moment(event.date).format('LL')}</span><br />
+              <span className={styles['fifteen-percent']}>{moment(event.date).format('LT')}</span>
             </div>
-          </div>
+          </Link>
+          { isAdmin || loggedIn ? (
+            <div className="card-action">
+              <React.Fragment>
+                <button
+                  onClick={() => { changeEvent(event.id); toggleEdit(); showModal(); }}
+                  className="waves-effect waves-light btn navbar-purple round-btn white-color left-align"
+                >
+                  <i className="material-icons">edit</i>
+                </button>
+                <button
+                  onClick={() => deleteEvent(event.id)}
+                  className="waves-effect waves-light btn navbar-purple round-btn white-color right"
+                >
+                  <i className="material-icons">delete</i>
+                </button>
+              </React.Fragment>
+            </div>
+          ) : (
+            <React.Fragment />
+          )}
         </div>
-    ))}
-    </div>
-  );
-};
+      </div>
+  ))}
+  </div>
+);
 EventsListWithImage.propTypes = {
   events: PropTypes.arrayOf(PropTypes.object).isRequired,
   isAdmin: PropTypes.bool.isRequired,

--- a/client/css/events.module.css
+++ b/client/css/events.module.css
@@ -185,3 +185,17 @@ a, a:link, a:visited, a:active {
   max-height: 100% !important;
   bottom: 5%;
 }
+.close {
+  cursor: pointer;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  padding: 10px;
+  background: #FFF;
+}
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/client/reducers/eventReducer.js
+++ b/client/reducers/eventReducer.js
@@ -63,6 +63,27 @@ export default function eventReducer(state = initialState.events, action) {
         }
       });
       return theState;
+    case types.ADD_EVENT_SUCCESS:
+      theState = update(state, {
+        events: {
+          $set: [
+            ...state.events.filter(event => event.id !== action.event.event.id),
+            Object.assign({}, action.event.event)
+          ]
+        },
+        isLoading: { $set: false }
+      });
+      return theState;
+    case types.ADD_EVENT_FAILURE:
+      theState = update(state, {
+        isLoading: { $set: false }
+      });
+      return theState;
+    case types.ADD_EVENT_LOADING:
+      theState = update(state, {
+        isLoading: { $set: true }
+      });
+      return theState;
     default:
       return state;
   }

--- a/template/css/index.css
+++ b/template/css/index.css
@@ -352,3 +352,11 @@ hr {
 .hvr-grow:active {
     transform: scale(1.1);
 }
+
+.display-block {
+  display: block;
+}
+
+.display-none {
+  display: none;
+}


### PR DESCRIPTION
#### What does this PR do?
fix issue where modals didn't always load when trying to update an event
#### Description of Task to be completed?
* create a `Modal` component
* use the component inside the `SingleCenter` component for both adding and editing events
* render the `AddEvent` component inside the modal when the user wants to create an event
* render the `EditEvent` component inside the modal when the user wants to update an event 
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `npm install` to install all dependecies
* run `npm run start:all` to start up the application
* go to `localhost:8080` on your browser
* click on `Signup`
* enter your details
* click on `Signup`
* request for admin access
* click on `Centers` on the navbar
* click on the red add button at the bottom right corner
* enter the details of the center
* click on `Add Center`
* add at least ten more centers
* click on `Centers`
* select a center
* click on the red add button at the bottom right corner
* enter the details of the event inside the modal that opens
* click on `Add Event`
* the modal should close and you should see the newly created event on the center's page
* click on the edit icon on the event's card
* edit the event name and date inside the modal that opens
* click on `Update Event`
* the modal should close and you should see the event with an updated name on the center's page
#### Any background context you want to provide?
modals didn't always open when trying to update an event prior to raising this PR
#### What are the relevant pivotal tracker stories?(if applicable)
#157770713