### PR TITLE
#157783443 Add centers using a modal

### DIFF
--- a/client/components/centers/containers/AddCenter.jsx
+++ b/client/components/centers/containers/AddCenter.jsx
@@ -165,7 +165,8 @@ export class AddCenter extends Component {
       this.props.centerActions.addCenter(center)
         .then((response) => {
           Materialize.toast(response, 4000, 'green');
-          history.push('/centers');
+          this.clearFields();
+          this.props.hideModal();
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
@@ -183,35 +184,37 @@ export class AddCenter extends Component {
     }
     return (
       <div className="container max-width-six-hundred">
-        <div className="card">
-          <div className="container">
-            <h3 className="center-heading">Add a Center</h3>
-          </div>
-          <CentersForm
-            nameClasses={nameClasses}
-            detailClasses={detailClasses}
-            addressClasses={addressClasses}
-            stateClasses={stateClasses}
-            capacityClasses={capacityClasses}
-            saveOrUpdate={this.addCenter}
-            handleChange={this.handleChange}
-            name={this.state.name}
-            chairs={this.state.chairs}
-            projector={this.state.projector}
-            capacity={this.state.capacity}
-            detail={this.state.detail}
-            address={this.state.address}
-            state={this.state.state}
-            image={this.state.image}
-          />
+        <div className="container">
+          <h3 className="center-heading">Add a Center</h3>
         </div>
+        <CentersForm
+          nameClasses={nameClasses}
+          detailClasses={detailClasses}
+          addressClasses={addressClasses}
+          stateClasses={stateClasses}
+          capacityClasses={capacityClasses}
+          saveOrUpdate={this.addCenter}
+          handleChange={this.handleChange}
+          name={this.state.name}
+          chairs={this.state.chairs}
+          projector={this.state.projector}
+          capacity={this.state.capacity}
+          detail={this.state.detail}
+          address={this.state.address}
+          state={this.state.state}
+          image={this.state.image}
+        />
       </div>
     );
   }
 }
 AddCenter.propTypes = {
   centerActions: PropTypes.objectOf(PropTypes.func).isRequired,
-  isLoading: PropTypes.bool.isRequired
+  isLoading: PropTypes.bool.isRequired,
+  hideModal: PropTypes.func
+};
+AddCenter.defaultProps = {
+  hideModal: () => {}
 };
 function mapStateToProps(state) {
   return {

--- a/client/components/centers/containers/Centers.jsx
+++ b/client/components/centers/containers/Centers.jsx
@@ -10,34 +10,46 @@ import * as centerActions from '../../../actions/centerActions';
 import CenterList from '../presentational/CenterList';
 import Search from '../../common/Search';
 import Preloader from '../../common/Preloader';
+import Modal from '../../common/Modal';
+import AddCenter from './AddCenter';
 import history from '../../../history';
 
 export class Centers extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      page: 1
+      show: false
     };
+    this.page = 1;
     this.changePage = this.changePage.bind(this);
+    this.showModal = this.showModal.bind(this);
+    this.hideModal = this.hideModal.bind(this);
   }
   componentDidMount() {
     const values = qs.parse(this.props.location.search);
-    let page;
     if (values.page === undefined) {
-      page = 1;
+      this.page = 1;
     } else {
-      page = parseInt(values.page, 10);
+      this.page = parseInt(values.page, 10);
     }
     if (this.props.centers.length === 0) {
-      this.props.centerActions.fetchCenters(page);
+      this.props.centerActions.fetchCenters(this.page);
     }
   }
   changePage(e) {
-    this.setState({
-      page: e
-    });
+    this.page = e;
     this.props.centerActions.fetchCenters(e);
     history.push(`/centers/?page=${e}`);
+  }
+  showModal() {
+    this.setState({
+      show: true
+    });
+  }
+  hideModal() {
+    this.setState({
+      show: false
+    });
   }
   render() {
     const { isAdmin = false } = this.props;
@@ -68,19 +80,22 @@ export class Centers extends Component {
           { pages !== 1 ? (
             <Pagination
               items={9}
-              activePage={this.state.page}
+              activePage={this.page}
               onSelect={this.changePage}
               maxButtons={pages}
             />
           ) : ''}
+          <Modal show={this.state.show} hideModal={this.hideModal}>
+            <AddCenter hideModal={this.hideModal} />
+          </Modal>
         </div>
         <div className="fixed-action-btn horizontal click-to-toggle">
-          <Link
-            to="/add-center"
+          <button
+            onClick={this.showModal}
             className="btn-floating btn-large red white-color"
           >
             <i className="material-icons">add</i>
-          </Link>
+          </button>
         </div>
       </React.Fragment>
     );

--- a/server/app.js
+++ b/server/app.js
@@ -47,7 +47,7 @@ const s3 = new AWS.S3();
 AWS.config.update({
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  subregion: 'us-east-1',
+  subregion: 'us-east-2',
 });
 
 


### PR DESCRIPTION
#### What does this PR do?
allow users add centers using a modal without redirecting from a page
#### Description of Task to be completed?
* use a modal when adding centers
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `npm install` to install all dependecies
* run `npm run start:all` to start up the application
* go to `localhost:8080` on your browser
* click on `Signup`
* enter your details
* click on `Signup`
* request for admin access
* click on `Centers` on the navbar
* click on the red add button at the bottom right corner
* a modal with the form used for adding centers should come up
* enter the details of the center
* click on Add Center
* the modal should close and you should see the new center on the page
#### Any background context you want to provide?
n/a
#### What are the relevant pivotal tracker stories?(if applicable)
#157783443