### PR TITLE
#157783407 Edit centers via modals

### DIFF
--- a/client/components/centers/containers/Centers.jsx
+++ b/client/components/centers/containers/Centers.jsx
@@ -12,18 +12,22 @@ import Search from '../../common/Search';
 import Preloader from '../../common/Preloader';
 import Modal from '../../common/Modal';
 import AddCenter from './AddCenter';
+import EditCenter from './EditCenter';
 import history from '../../../history';
 
 export class Centers extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      show: false
+      show: false,
+      editMode: false
     };
     this.page = 1;
     this.changePage = this.changePage.bind(this);
     this.showModal = this.showModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
+    this.changeCenter = this.changeCenter.bind(this);
+    this.toggleEdit = this.toggleEdit.bind(this);
   }
   componentDidMount() {
     const values = qs.parse(this.props.location.search);
@@ -48,7 +52,18 @@ export class Centers extends Component {
   }
   hideModal() {
     this.setState({
-      show: false
+      show: false,
+      editMode: false
+    });
+  }
+  toggleEdit() {
+    this.setState({
+      editMode: !this.state.editMode
+    });
+  }
+  changeCenter(centerId) {
+    this.setState({
+      centerId
     });
   }
   render() {
@@ -75,7 +90,13 @@ export class Centers extends Component {
           <Search />
           <div className="top-ten-padding" />
           <div className="row">
-            <CenterList centers={centers} isAdmin={isAdmin} />
+            <CenterList
+              centers={centers}
+              isAdmin={isAdmin}
+              toggleEdit={this.toggleEdit}
+              changeCenter={this.changeCenter}
+              showModal={this.showModal}
+            />
           </div>
           { pages !== 1 ? (
             <Pagination
@@ -86,7 +107,14 @@ export class Centers extends Component {
             />
           ) : ''}
           <Modal show={this.state.show} hideModal={this.hideModal}>
-            <AddCenter hideModal={this.hideModal} />
+            { !this.state.editMode ? (
+              <AddCenter hideModal={this.hideModal} />
+            ) : (
+              <EditCenter
+                hideModal={this.hideModal}
+                centerId={this.state.centerId}
+              />
+            )}
           </Modal>
         </div>
         <div className="fixed-action-btn horizontal click-to-toggle">

--- a/client/components/centers/containers/EditCenter.jsx
+++ b/client/components/centers/containers/EditCenter.jsx
@@ -7,7 +7,6 @@ import validator from 'validator';
 import * as centerActions from '../../../actions/centerActions';
 import * as singleCenterActions from '../../../actions/singleCenterActions';
 import CentersForm from '../presentational/CentersForm';
-import history from '../../../history';
 
 export class EditCenter extends Component {
   constructor(props) {
@@ -26,7 +25,7 @@ export class EditCenter extends Component {
     this.updateCenter = this.updateCenter.bind(this);
   }
   componentDidMount() {
-    this.props.actions.fetchSingleCenter(parseInt(this.props.match.params.id, 10));
+    this.props.actions.fetchSingleCenter(this.props.centerId);
   }
   componentWillReceiveProps(nextProps) {
     if (this.props.center.id !== nextProps.center.id) {
@@ -156,11 +155,25 @@ export class EditCenter extends Component {
     });
     this.setState(state);
   }
+  clearFields() {
+    this.setState({
+      name: {
+        value: '', isValid: true, message: ''
+      }
+    });
+    this.setState({ capacity: { value: '', isValid: true, message: '' } });
+    this.setState({ address: { value: '', isValid: true, message: '' } });
+    this.setState({ state: { value: '', isValid: true, message: '' } });
+    this.setState({ detail: { value: '', isValid: true, message: '' } });
+    this.setState({ chairs: { value: '', isValid: true, message: '' } });
+    this.setState({ projector: { value: '', isValid: true, message: '' } });
+    this.setState({ image: { value: '', isValid: true, message: '' } });
+  }
   updateCenter(event) {
     event.preventDefault();
     this.resetValidationStates();
     const center = {
-      id: this.props.match.params.id,
+      id: this.props.centerId,
       name: this.state.name.value,
       capacity: this.state.capacity.value,
       address: this.state.address.value,
@@ -174,7 +187,8 @@ export class EditCenter extends Component {
       this.props.actions.updateCenter(center)
         .then((response) => {
           Materialize.toast(response.message, 4000, 'green');
-          history.push(`/centers/${response.center.id}`);
+          this.clearFields();
+          this.props.hideModal();
         })
         .catch(error => Materialize.toast(error, 4000, 'red'));
     }
@@ -187,29 +201,27 @@ export class EditCenter extends Component {
     const capacityClasses = classNames('help-block', { 'has-error': !this.state.capacity.isValid });
     return (
       <div className="container max-width-six-hundred">
-        <div className="card">
-          <div className="container">
-            <h3 className="center-heading">Edit a Center</h3>
-          </div>
-          <CentersForm
-            nameClasses={nameClasses}
-            detailClasses={detailClasses}
-            addressClasses={addressClasses}
-            stateClasses={stateClasses}
-            capacityClasses={capacityClasses}
-            saveOrUpdate={this.updateCenter}
-            handleChange={this.handleChange}
-            name={this.state.name}
-            chairs={this.state.chairs}
-            projector={this.state.projector}
-            capacity={this.state.capacity}
-            detail={this.state.detail}
-            address={this.state.address}
-            state={this.state.state}
-            image={this.state.image}
-            component="Edit"
-          />
+        <div className="container">
+          <h3 className="center-heading">Edit a Center</h3>
         </div>
+        <CentersForm
+          nameClasses={nameClasses}
+          detailClasses={detailClasses}
+          addressClasses={addressClasses}
+          stateClasses={stateClasses}
+          capacityClasses={capacityClasses}
+          saveOrUpdate={this.updateCenter}
+          handleChange={this.handleChange}
+          name={this.state.name}
+          chairs={this.state.chairs}
+          projector={this.state.projector}
+          capacity={this.state.capacity}
+          detail={this.state.detail}
+          address={this.state.address}
+          state={this.state.state}
+          image={this.state.image}
+          component="Edit"
+        />
       </div>
     );
   }
@@ -228,15 +240,16 @@ EditCenter.propTypes = {
     events: PropTypes.array
   }).isRequired,
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.node,
-    }).isRequired,
-  }).isRequired
+  hideModal: PropTypes.func,
+  centerId: PropTypes.number
+};
+EditCenter.defaultProps = {
+  hideModal: () => {},
+  centerId: 1
 };
 function mapStateToProps(state) {
   let center;
-  if (state.center && state.center.id === '') {
+  if (state.centers.center && state.centers.center.id === '') {
     center = {
       id: '',
       name: '',
@@ -250,7 +263,7 @@ function mapStateToProps(state) {
       events: []
     };
   } else {
-    ({ center } = state);
+    ({ centers: { center } } = state);
   }
   return {
     center

--- a/client/components/centers/presentational/CenterList.jsx
+++ b/client/components/centers/presentational/CenterList.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import * as styles from '../../../css/centers.module.css';
 
-const CenterList = ({ centers, isAdmin }) => (
+const CenterList = ({
+  centers, isAdmin, showModal, toggleEdit, changeCenter
+}) => (
   <div>
     {centers.map(center => (
       <div className="col s12 m6 l4 hvr-grow" key={center.id}>
-        <Link to={`/centers/${center.id}`}>
-          <div className="card z-depth-2">
+        <div className="card z-depth-2">
+          <Link to={`/centers/${center.id}`}>
             <div className="card-image">
               <img src={center.image} className="center-image" alt={`${center.name}`} />
               { /*
@@ -23,26 +25,34 @@ const CenterList = ({ centers, isAdmin }) => (
               </span><br />
               <span className={styles['center-address']}>{center.address}</span>
             </div>
-            { isAdmin ? (
-              <div className="card-action">
-                <Link
-                  to={`/centers/${center.id}/edit`}
-                  className="waves-effect waves-light btn navbar-purple round-btn white-color"
-                >
-                  <i className="material-icons">edit</i>
-                </Link>
-              </div>
-          ) : (
-            <React.Fragment />
-            )}
-          </div>
-        </Link>
+          </Link>
+          { isAdmin ? (
+            <div className="card-action">
+              <button
+                onClick={() => { showModal(); toggleEdit(); changeCenter(center.id); }}
+                className="waves-effect waves-light btn navbar-purple round-btn white-color"
+              >
+                <i className="material-icons">edit</i>
+              </button>
+            </div>
+        ) : (
+          <React.Fragment />
+          )}
+        </div>
       </div>
     ))}
   </div>
 );
 CenterList.propTypes = {
   centers: PropTypes.arrayOf(PropTypes.object).isRequired,
-  isAdmin: PropTypes.bool.isRequired
+  isAdmin: PropTypes.bool.isRequired,
+  showModal: PropTypes.func,
+  toggleEdit: PropTypes.func,
+  changeCenter: PropTypes.func
+};
+CenterList.defaultProps = {
+  showModal: () => {},
+  toggleEdit: () => {},
+  changeCenter: () => {}
 };
 export default CenterList;

--- a/client/components/centers/presentational/CentersForm.jsx
+++ b/client/components/centers/presentational/CentersForm.jsx
@@ -6,7 +6,7 @@ const CentersForm = ({
   nameClasses, detailClasses, capacityClasses, addressClasses, stateClasses, saveOrUpdate,
   component, image
 }) => (
-  <form className="card-content">
+  <form>
     <div className="row">
       <div className="input-field col s12">
         <input


### PR DESCRIPTION
#### What does this PR do?
allow admin edit centers using a modal
#### Description of Task to be completed?
* render the `EditCenter` component inside the `Modal` component in the `Centers` if a value in state is true
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `npm install` to install all dependecies
* run `npm run start:all` to start up the application
* go to `localhost:8080` on your browser
* click on `Signup`
* enter your details
* click on Signup
* request for admin access
* click on Centers on the navbar
* click on the red add button at the bottom right corner
* a modal with the form used for adding centers should come up
* enter the details of the center
* click on Add Center
* the modal should close and you should see the new center on the page
* click on the edit icon on the center
* a modal should open with the center's details pre-filled in
* edit the name
* click on `Update Center`
* the modal should close and you should see the new name reflected on the center's card
#### Any background context you want to provide?
n/a
#### What are the relevant pivotal tracker stories?(if applicable)
